### PR TITLE
Get all plans use plan service getall plans method

### DIFF
--- a/src/main/java/org/opensrp/web/rest/PlanResource.java
+++ b/src/main/java/org/opensrp/web/rest/PlanResource.java
@@ -76,10 +76,10 @@ public class PlanResource {
 	}
 
 	@RequestMapping(method = RequestMethod.GET, produces = { MediaType.APPLICATION_JSON_VALUE })
-	public ResponseEntity<String> getPlans(@RequestParam(value = FIELDS, required = false) List<String> fields) {
+	public ResponseEntity<String> getPlans() {
 		try {
 			return new ResponseEntity<>(gson.toJson(
-					planService.getPlansByIdsReturnOptionalFields(null, fields)),
+					planService.getAllPlans()),
 					RestUtils.getJSONUTF8Headers(), HttpStatus.OK);
 		} catch (Exception e) {
 			logger.error(e.getMessage(), e);

--- a/src/test/java/org/opensrp/web/rest/PlanResourceTest.java
+++ b/src/test/java/org/opensrp/web/rest/PlanResourceTest.java
@@ -160,7 +160,7 @@ public class PlanResourceTest extends BaseResourceTest<PlanDefinition> {
 
         expectedPlans.add(expectedPlan);
 
-        doReturn(expectedPlans).when(planService).getPlansByIdsReturnOptionalFields(anyList(), anyList());
+        doReturn(expectedPlans).when(planService).getAllPlans();
 
         String actualPlansString = getResponseAsString(BASE_URL, null, MockMvcResultMatchers.status().isOk());
         List<PlanDefinition> actualPlans = new Gson().fromJson(actualPlansString, new TypeToken<List<PlanDefinition>>(){}.getType());


### PR DESCRIPTION
Revert functionality for getAll Plans API endpoint.

Currently its duplicating plans by the number of jurisdictions per plan