### PR TITLE
Configure optional sync profiles with default profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -567,6 +567,8 @@
 			</activation>
 			<properties>
 				<opensrp.database.profile>postgres</opensrp.database.profile>
+				<openmrs.sync.enabled>default</openmrs.sync.enabled>
+				<dhis2.sync.enabled>default</dhis2.sync.enabled>
 			</properties>
 		</profile>
 		<profile>


### PR DESCRIPTION
Resolves #250 

Configure optional sync profiles variables with default profile

This is to allow specifying or omitting the default profiles 
- openmrs-sync
- dhis2-sync