### PR TITLE
WIP  Refactor RapidProResource remove information leak

### DIFF
--- a/src/main/java/org/opensrp/web/rest/rapid/RapidProResource.java
+++ b/src/main/java/org/opensrp/web/rest/rapid/RapidProResource.java
@@ -160,7 +160,8 @@ public class RapidProResource {
 	private List<RapidProContact> addNewContacts(Event event) {
 		List<RapidProContact> rapidProContacts = new ArrayList<>();
 		RapidProContact rapidProContact = new RapidProContact();
-		Client contactMother, contactChild;
+		Client contactMother;
+		Client contactChild;
 		List<Obs> obs;
 		if (event.getBaseEntityId() != null && !event.getBaseEntityId().isEmpty() && event.getEventType() != null && event.getEventType().equals(BIRTH_REGISTRATION)) {
 			rapidProContact = new RapidProContact();

--- a/src/main/java/org/opensrp/web/rest/rapid/RapidProResource.java
+++ b/src/main/java/org/opensrp/web/rest/rapid/RapidProResource.java
@@ -52,16 +52,6 @@ public class RapidProResource {
 
 	private PatientService patientService;
 
-	private List<Event> events;
-
-	private List<RapidProContact> rapidProContacts;
-
-	private RapidProContact rapidProContact;
-
-	private Client contactMother, contactChild;
-
-	private List<Obs> obs;
-
 	private Gson gson = new GsonBuilder().setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ").registerTypeAdapter(DateTime.class, new DateTimeTypeConverter()).create();
 
 	@Autowired
@@ -74,8 +64,9 @@ public class RapidProResource {
 	@RequestMapping(value = "/sync", method = RequestMethod.GET)
 	@ResponseBody
 	protected ResponseEntity<String> getNewContacts(HttpServletRequest request) {
+		List<Event> events;
+		List<RapidProContact> rapidProContacts = new ArrayList<>();
 		Map<String, Object> response = new HashMap<>();
-		rapidProContacts = new ArrayList<>();
 		try {
 			String serverVersion = getStringFilter(BaseEntity.SERVER_VERSIOIN, request);
 			String eventType = getStringFilter(EVENT_TYPE, request);
@@ -98,7 +89,7 @@ public class RapidProResource {
 				if (!events.isEmpty() && events != null) {
 					for (Event event : events) {
 						try {
-							addNewContacts(event);
+							rapidProContacts = addNewContacts(event);
 						}
 						catch (Exception e) {
 							e.printStackTrace();
@@ -166,7 +157,11 @@ public class RapidProResource {
 		return new ResponseEntity<>(gson.toJson(response), HttpStatus.OK);
 	}
 
-	private void addNewContacts(Event event) {
+	private List<RapidProContact> addNewContacts(Event event) {
+		List<RapidProContact> rapidProContacts = new ArrayList<>();
+		RapidProContact rapidProContact = new RapidProContact();
+		Client contactMother, contactChild;
+		List<Obs> obs;
 		if (event.getBaseEntityId() != null && !event.getBaseEntityId().isEmpty() && event.getEventType() != null && event.getEventType().equals(BIRTH_REGISTRATION)) {
 			rapidProContact = new RapidProContact();
 			contactChild = clientService.getByBaseEntityId(event.getBaseEntityId());
@@ -187,7 +182,7 @@ public class RapidProResource {
 			}
 			if ((rapidProContact.getMotherTel() == null || StringUtils.isBlank(rapidProContact.getMotherTel())) && rapidProContact.getMvaccUuid() == null || !StringUtils.isBlank(rapidProContact.getMvaccUuid())) {
 				rapidProContacts.add(rapidProContact);
-				return;
+				return rapidProContacts;
 			}
 
 			List<Client> clients = clientService.findByRelationship(contactMother.getBaseEntityId());
@@ -229,6 +224,7 @@ public class RapidProResource {
 
 		}
 		rapidProContacts.add(rapidProContact);
+		return rapidProContacts;
 	}
 
 	private static Comparator<Client> COMPARATOR = new Comparator<Client>() {


### PR DESCRIPTION
Issue # 278

Refactor RapidProResource remove information leak.
There below variables are defines globally on the access which mean values are shared across all threads that make requests to the API
	private List<Event> events;
	private List<RapidProContact> rapidProContacts;
	private RapidProContact rapidProContact;
	private Client contactMother, contactChild;
	private List<Obs> obs;

Move these variables to local variables on the functions that use them so that they are then request variables