### PR TITLE
254 : UniqueID API support Access via Access tokens

### DIFF
--- a/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
@@ -54,7 +54,7 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
 		http.cors()
 		.and()
 			.anonymous().disable()
-		.requestMatchers().mvcMatchers("/rest/**","/user-details","/security/**")
+		.requestMatchers().mvcMatchers("/rest/**","/user-details","/security/**", "/uniqueids/*")
 		.and()
 			.authorizeRequests()
 				.mvcMatchers("/rest/*/getAll").hasRole(Role.ALL_EVENTS)


### PR DESCRIPTION
Issue # 254
To allow accessing UniqueIdController API's while using Bearer tokens for authentication.