### PR TITLE
Fix bug XSS wrapper use getInputSteam in overridden method

### DIFF
--- a/src/main/java/org/opensrp/web/config/security/filter/XssPreventionRequestWrapper.java
+++ b/src/main/java/org/opensrp/web/config/security/filter/XssPreventionRequestWrapper.java
@@ -41,7 +41,7 @@ public class XssPreventionRequestWrapper extends HttpServletRequestWrapper {
 	@Override
 	public ServletInputStream getInputStream() throws IOException {
 		if (rawData == null) {
-			rawData = IOUtils.toByteArray(this.request.getReader());
+			rawData = IOUtils.toByteArray(this.request.getInputStream());
 			servletStream.stream = new ByteArrayInputStream(rawData);
 		}
 		updateParameters();
@@ -51,7 +51,7 @@ public class XssPreventionRequestWrapper extends HttpServletRequestWrapper {
 	@Override
 	public BufferedReader getReader() throws IOException {
 		if (rawData == null) {
-			rawData = IOUtils.toByteArray(this.request.getReader());
+			rawData = IOUtils.toByteArray(this.request.getReader(),StandardCharsets.UTF_8);
 			servletStream.stream = new ByteArrayInputStream(rawData);
 		}
 		updateParameters();


### PR DESCRIPTION
- [x] Fix bug XSS wrapper use getInputSteam in overridden method.

This was causing errors as on below stacktrace

```
java.lang.IllegalStateException: getInputStream() has already been called for this request
	at org.apache.catalina.connector.Request.getReader(Request.java:1208)
	at org.apache.catalina.connector.RequestFacade.getReader(RequestFacade.java:504)
	at javax.servlet.ServletRequestWrapper.getReader(ServletRequestWrapper.java:230)
	at javax.servlet.ServletRequestWrapper.getReader(ServletRequestWrapper.java:230)
	at javax.servlet.ServletRequestWrapper.getReader(ServletRequestWrapper.java:230)
	at javax.servlet.ServletRequestWrapper.getReader(ServletRequestWrapper.java:230)
	at org.opensrp.web.config.security.filter.XssPreventionRequestWrapper.getInputStream(XssPreventionRequestWrapper.java:44)
```