### PR TITLE
Multimedia exceptions catch in global exception handler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.2.2-SNAPSHOT</version>
+	<version>2.2.3-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/config/security/SecurityConfig.java
+++ b/src/main/java/org/opensrp/web/config/security/SecurityConfig.java
@@ -98,7 +98,7 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 			.anyRequest().authenticated()
 		.and()
     		.csrf()
-    		.ignoringAntMatchers("/rest/**")
+    		.ignoringAntMatchers("/rest/**","/multimedia/**")
     	.and()
     		.httpBasic();/*
     	.and()

--- a/src/test/java/org/opensrp/web/controller/MultimediaControllerTest.java
+++ b/src/test/java/org/opensrp/web/controller/MultimediaControllerTest.java
@@ -83,10 +83,10 @@ public class MultimediaControllerTest {
 		
 		MultimediaService multimediaService = mock(MultimediaService.class);
 		HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
-		Mockito.when(httpServletResponse.getOutputStream()).thenReturn(Mockito.mock(ServletOutputStream.class));
+		when(httpServletResponse.getOutputStream()).thenReturn(mock(ServletOutputStream.class));
 		Whitebox.setInternalState(controller, "multimediaService", multimediaService);
 		File file= new File("opensrp-server-web/src/main/webapp/resources/opensrp_logo.png");
-		Mockito.when(multimediaService.retrieveFile(anyString())).thenReturn(file);
+		when(multimediaService.retrieveFile(anyString())).thenReturn(file);
 		controller.downloadFileWithAuth(httpServletResponse, "fileName");
 		
 		// verify call to the service

--- a/src/test/java/org/opensrp/web/controller/MultimediaControllerTest.java
+++ b/src/test/java/org/opensrp/web/controller/MultimediaControllerTest.java
@@ -8,7 +8,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 import java.io.File;
+import java.io.IOException;
 
+import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
 import org.junit.Before;
@@ -76,13 +78,15 @@ public class MultimediaControllerTest {
 	}
 	
 	@Test
-	public void testDownloadWithAuth() {
+	public void testDownloadWithAuth() throws IOException {
 		MultimediaController controller = Mockito.spy(new MultimediaController());
 		
 		MultimediaService multimediaService = mock(MultimediaService.class);
 		HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+		Mockito.when(httpServletResponse.getOutputStream()).thenReturn(Mockito.mock(ServletOutputStream.class));
 		Whitebox.setInternalState(controller, "multimediaService", multimediaService);
-		
+		File file= new File("opensrp-server-web/src/main/webapp/resources/opensrp_logo.png");
+		Mockito.when(multimediaService.retrieveFile(anyString())).thenReturn(file);
 		controller.downloadFileWithAuth(httpServletResponse, "fileName");
 		
 		// verify call to the service


### PR DESCRIPTION
- [x] Multimedia exceptions catch in global exception handler so that errors are not muted but 500 status code is returned

- [x] Exempt CSRF in multimedia uploads