### PR TITLE
Add strict param in Manifest API Search endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
 		<opensrp.updatePolicy>always</opensrp.updatePolicy>
 		<nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-		<opensrp.core.version>2.3.1-SNAPSHOT</opensrp.core.version>
+		<opensrp.core.version>2.3.2-SNAPSHOT</opensrp.core.version>
 		<opensrp.connector.version>2.0.1-SNAPSHOT</opensrp.connector.version>
 		<opensrp.common.version>2.0.1-SNAPSHOT</opensrp.common.version>
 		<opensrp.interface.version>2.0.0-SNAPSHOT</opensrp.interface.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
 		<opensrp.updatePolicy>always</opensrp.updatePolicy>
 		<nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-		<opensrp.core.version>2.2.0-SNAPSHOT</opensrp.core.version>
+		<opensrp.core.version>2.3.1-SNAPSHOT</opensrp.core.version>
 		<opensrp.connector.version>2.0.1-SNAPSHOT</opensrp.connector.version>
 		<opensrp.common.version>2.0.1-SNAPSHOT</opensrp.common.version>
 		<opensrp.interface.version>2.0.0-SNAPSHOT</opensrp.interface.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.2.3-SNAPSHOT</version>
+	<version>2.2.4-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/Constants.java
+++ b/src/main/java/org/opensrp/web/Constants.java
@@ -23,4 +23,14 @@ public interface Constants {
         String APPLICATION_YAML = "application/x-yaml";
         String TEXT_YAML = "text/yaml";
     }
+
+    interface EndpointParam {
+        String APP_ID = "app_id";
+        String STRICT = "strict";
+        String APP_VERSION = "app_version";
+    }
+
+    interface DefaultEndpointParam {
+        String FALSE = "false";
+    }
 }

--- a/src/main/java/org/opensrp/web/rest/ManifestResource.java
+++ b/src/main/java/org/opensrp/web/rest/ManifestResource.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.opensrp.domain.Manifest;
 import org.opensrp.service.ManifestService;
+import org.opensrp.web.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ import java.util.Set;
 public class ManifestResource {
 
     private static Logger logger = LoggerFactory.getLogger(ManifestResource.class.toString());
+    public static final String FALSE = Boolean.FALSE.toString();
     private ManifestService manifestService;
     public static final String IDENTIFIER = "identifier";
     protected ObjectMapper objectMapper;
@@ -103,9 +105,9 @@ public class ManifestResource {
     @RequestMapping(value = "/search", method = RequestMethod.GET, produces = {
             MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<String> getManifestByAppIdAndAppVersion(
-            @RequestParam(value = "app_version") String appVersion,
-            @RequestParam(value = "app_id") String appId,
-            @RequestParam(value = "strict", defaultValue = "false") String strict) throws JsonProcessingException {
+            @RequestParam(value = Constants.EndpointParam.APP_VERSION) String appVersion,
+            @RequestParam(value = Constants.EndpointParam.APP_ID) String appId,
+            @RequestParam(value = Constants.EndpointParam.STRICT, defaultValue = Constants.DefaultEndpointParam.FALSE) String strict) throws JsonProcessingException {
         boolean strictSearch = Boolean.parseBoolean(strict.toLowerCase());
         Manifest manifest = null;
 


### PR DESCRIPTION
- Enable the API to return the next available version(lower) of a manifest when strict param is not defined or when the strict param is false
- The API will return 404 when the strict param is true & manifest is not found

Fixes #331