### PR TITLE
Fix session replication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - sudo updatedb #Giving couchdb time to start.
   - sudo netstat -tuplen # listing all the port for debug purpose.
 before_script:
+  - sudo redis-server /etc/redis/redis.conf --port 6379 --requirepass 'RedI$P@S5'
   - curl -X PUT http://localhost:5984/_config/admins/rootuser -d '"adminpass"'
   - echo "USE mysql;\nUPDATE user SET password=PASSWORD('VA1913wm') WHERE user='root';\nFLUSH PRIVILEGES;\n" | mysql -u root
   - sudo /etc/init.d/postgresql stop

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.1.15-SNAPSHOT</version>
+	<version>2.1.16-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/config/security/HttpSessionConfig.java
+++ b/src/main/java/org/opensrp/web/config/security/HttpSessionConfig.java
@@ -1,13 +1,9 @@
 package org.opensrp.web.config.security;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.session.data.redis.config.ConfigureRedisAction;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
-import org.springframework.session.web.http.HeaderHttpSessionIdResolver;
-import org.springframework.session.web.http.HttpSessionIdResolver;
 
 @Configuration
 @EnableRedisHttpSession
@@ -16,13 +12,4 @@ public class HttpSessionConfig {
 	@Autowired
 	private RedisConnectionFactory redisConnectionFactory;
 
-	/*@Bean
-	public HttpSessionIdResolver httpSessionIdResolver() {
-		return HeaderHttpSessionIdResolver.xAuthToken();
-	}
-	
-	@Bean
-	public static ConfigureRedisAction configureRedisAction() {
-		return ConfigureRedisAction.NO_OP;
-	}*/
 }

--- a/src/main/java/org/opensrp/web/config/security/HttpSessionConfig.java
+++ b/src/main/java/org/opensrp/web/config/security/HttpSessionConfig.java
@@ -16,13 +16,13 @@ public class HttpSessionConfig {
 	@Autowired
 	private RedisConnectionFactory redisConnectionFactory;
 
-	@Bean
+	/*@Bean
 	public HttpSessionIdResolver httpSessionIdResolver() {
 		return HeaderHttpSessionIdResolver.xAuthToken();
 	}
-
+	
 	@Bean
 	public static ConfigureRedisAction configureRedisAction() {
 		return ConfigureRedisAction.NO_OP;
-	}
+	}*/
 }


### PR DESCRIPTION
- [x] Session Store Identifier in Cookies.

- [x] Using headers breaks Oauth handshake as headers are not retained for the next subsequent calls.

- [x] Session cookie identifier is used so that its persisted on subsequent requests
