### PR TITLE
Validate client form uploads are valid JSON, YAML Rule definition & ML properties file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,11 @@
 			<artifactId>maven-artifact</artifactId>
 			<version>3.0.3</version>
 		</dependency>
+		<dependency>
+			<groupId>org.jeasy</groupId>
+			<artifactId>easy-rules-mvel</artifactId>
+			<version>3.3.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.1.18-SNAPSHOT</version>
+	<version>2.1.19-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/rest/ClientFormResource.java
+++ b/src/main/java/org/opensrp/web/rest/ClientFormResource.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.Date;
 import java.util.List;
+import java.util.Properties;
 
 @Controller
 @RequestMapping(value = "/rest/clientForm")
@@ -211,7 +212,13 @@ public class ClientFormResource {
             }
         } else {
             // This is a properties file
-
+            try {
+                Properties properties = new Properties();
+                properties.load(new StringReader(fileContentString));
+            } catch (Exception e) {
+                e.printStackTrace();
+                return e.getMessage();
+            }
         }
 
         return null;

--- a/src/main/java/org/opensrp/web/rest/ClientFormResource.java
+++ b/src/main/java/org/opensrp/web/rest/ClientFormResource.java
@@ -4,12 +4,13 @@ package org.opensrp.web.rest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.IOException;
-import java.util.Date;
-import java.util.List;
 import org.apache.http.entity.ContentType;
 import org.apache.http.util.TextUtils;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.jeasy.rules.mvel.MVELRuleFactory;
+import org.jeasy.rules.support.YamlRuleDefinitionReader;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.opensrp.domain.IdVersionTuple;
 import org.opensrp.domain.postgres.ClientForm;
 import org.opensrp.domain.postgres.ClientFormMetadata;
@@ -28,8 +29,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Date;
+import java.util.List;
 
 @Controller
 @RequestMapping(value = "/rest/clientForm")
@@ -160,9 +164,15 @@ public class ClientFormResource {
             return new ResponseEntity<>("Invalid file", HttpStatus.BAD_REQUEST);
         }
 
-        String jsonString = new String(bytes);
-        logger.info(jsonString);
-        clientForm.setJson(jsonString);
+        String fileContentString = new String(bytes);
+
+        String errorMessageForInvalidContent = checkValidJsonYamlPropertiesStructure(fileContentString, fileContentType);
+        if (errorMessageForInvalidContent != null) {
+            return new ResponseEntity<>("File content error:\n" + errorMessageForInvalidContent, HttpStatus.BAD_REQUEST);
+        }
+
+        logger.info(fileContentString);
+        clientForm.setJson(fileContentString);
         clientForm.setCreatedAt(new Date());
 
         ClientFormMetadata clientFormMetadata = new ClientFormMetadata();
@@ -182,9 +192,39 @@ public class ClientFormResource {
     }
 
     @VisibleForTesting
+    @Nullable
+    protected String checkValidJsonYamlPropertiesStructure(@NonNull String fileContentString, @NonNull String contentType) {
+        if (contentType.equals(ContentType.APPLICATION_JSON.getMimeType())) {
+            try {
+                new JSONObject(fileContentString);
+                return null;
+            } catch (JSONException ex) {
+                logger.error("JSON File upload is invalid JSON", ex);
+                return ex.getMessage();
+            }
+        } else if (isYamlContentType(contentType)) {
+            try {
+                (new MVELRuleFactory(new YamlRuleDefinitionReader())).createRule(new BufferedReader(new StringReader(fileContentString)));
+            } catch (Exception ex) {
+                logger.error("Rules file upload is invalid YAML rules file", ex);
+                return ex.getMessage();
+            }
+        } else {
+            // This is a properties file
+
+        }
+
+        return null;
+    }
+
+    @VisibleForTesting
     protected boolean isClientFormContentTypeValid(@Nullable String fileContentType) {
         return fileContentType != null && (fileContentType.equals(ContentType.APPLICATION_JSON.getMimeType()) ||
-                fileContentType.equals(Constants.ContentType.APPLICATION_YAML) || fileContentType.equals(Constants.ContentType.TEXT_YAML));
+                isYamlContentType(fileContentType));
+    }
+
+    private boolean isYamlContentType(@NonNull String fileContentType) {
+        return fileContentType.equals(Constants.ContentType.APPLICATION_YAML) || fileContentType.equals(Constants.ContentType.TEXT_YAML);
     }
 
     @VisibleForTesting

--- a/src/test/java/org/opensrp/web/rest/ClientFormResourceTest.java
+++ b/src/test/java/org/opensrp/web/rest/ClientFormResourceTest.java
@@ -37,11 +37,13 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.server.request.MockMvcRequestBuilders.fileUpload;
 import static org.springframework.test.web.server.request.MockMvcRequestBuilders.get;
@@ -253,6 +255,32 @@ public class ClientFormResourceTest {
     }
 
     @Test
+    public void testAddClientFormWhenGivenInvalidJSONShouldReturn400() throws Exception {
+        String formIdentifier = "opd/reg.json";
+        String formVersion = "0.1.1";
+        String formName = "REGISTRATION FORM";
+
+        MockMultipartFile file = new MockMultipartFile("form", "path/to/opd/reg.json",
+                "application/json", TestFileContent.JSON_FORM_FILE.substring(0, 20).getBytes());
+
+        when(clientFormService.addClientForm(any(ClientForm.class), any(ClientFormMetadata.class))).thenReturn(mock(ClientFormService.CompleteClientForm.class));
+
+        MvcResult result = mockMvc.perform(
+                fileUpload(BASE_URL)
+                        .file(file)
+                        .param("form_identifier", formIdentifier)
+                        .param("form_version", formVersion)
+                        .param("form_name", formName))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        verifyNoInteractions(clientFormService);
+
+        String errorMessage = result.getResponse().getContentAsString();
+        assertEquals("File content error:", errorMessage.substring(0, 19));
+    }
+
+    @Test
     public void testAddClientFormWhenGivenYaml() throws Exception {
         String formIdentifier = "opd/calculation.yaml";
         String formVersion = "0.1.1";
@@ -282,6 +310,34 @@ public class ClientFormResourceTest {
         assertEquals(formVersion, clientFormMetadata.getVersion());
         assertEquals(formName, clientFormMetadata.getLabel());
         assertNull(clientFormMetadata.getModule());
+    }
+
+    @Test
+    public void testAddClientFormWhenGivenInvalidYamlShouldReturn400() throws Exception {
+        String formIdentifier = "opd/calculation.yaml";
+        String formVersion = "0.1.1";
+        String formName = "Calculation file";
+
+        MockMultipartFile file = new MockMultipartFile("form", "path/to/opd/calculation.yaml",
+                "application/x-yaml", TestFileContent.CALCULATION_YAML_FILE_CONTENT.substring(0, 10).getBytes());
+
+        when(clientFormService.addClientForm(any(ClientForm.class), any(ClientFormMetadata.class))).thenReturn(mock(ClientFormService.CompleteClientForm.class));
+
+        MvcResult result = mockMvc.perform(
+                fileUpload(BASE_URL)
+                        .file(file)
+                        .param("form_identifier", formIdentifier)
+                        .param("form_version", formVersion)
+                        .param("form_name", formName))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        ArgumentCaptor<ClientForm> clientFormArgumentCaptor = ArgumentCaptor.forClass(ClientForm.class);
+        ArgumentCaptor<ClientFormMetadata> clientFormMetadataArgumentCaptor = ArgumentCaptor.forClass(ClientFormMetadata.class);
+        verifyNoInteractions(clientFormService);
+
+        String errorMessage = result.getResponse().getContentAsString();
+        assertEquals("File content error:", errorMessage.substring(0, 19));
     }
 
     @Test
@@ -344,6 +400,18 @@ public class ClientFormResourceTest {
     public void testIsPropertiesFileShouldReturnFalse() {
         ClientFormResource clientFormResource = webApplicationContext.getBean(ClientFormResource.class);
         assertFalse(clientFormResource.isPropertiesFile("application/octet-stream", "anc_register"));
+    }
+
+    @Test
+    public void testCheckValidContentShouldReturnErrorMessageWhenGivenInvalidJSONStructure() {
+        ClientFormResource clientFormResource = webApplicationContext.getBean(ClientFormResource.class);
+        assertNotNull(clientFormResource.checkValidJsonYamlPropertiesStructure(TestFileContent.JSON_FORM_FILE.substring(0, 10), "application/json"));
+    }
+
+    @Test
+    public void testCheckValidJsonYamlPropertiesStructureShouldReturnErrorMessageWhenGivenInvalidYamlStructure() {
+        ClientFormResource clientFormResource = webApplicationContext.getBean(ClientFormResource.class);
+        assertNotNull(clientFormResource.checkValidJsonYamlPropertiesStructure(TestFileContent.CALCULATION_YAML_FILE_CONTENT.substring(0, 10), "application/x-yaml"));
     }
 
 }


### PR DESCRIPTION
- If the content is not valid JSON, MVEL YAML Rule OR ML properties file, then a 400 is returned with a clear message on the error
- Fixes #328