### PR TITLE
Fix add event bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.1.19-SNAPSHOT</version>
+	<version>2.1.20-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/rest/EventResource.java
+++ b/src/main/java/org/opensrp/web/rest/EventResource.java
@@ -333,7 +333,7 @@ public class EventResource extends RestResource<Event> {
 
 			if (syncData.has("clients")) {
 
-				ArrayList<Client> clients = gson.fromJson(syncData.getString("clients"),
+				ArrayList<Client> clients = gson.fromJson(syncData.getJSONArray("clients").toString(),
 				    new TypeToken<ArrayList<Client>>() {}.getType());
 				for (Client client : clients) {
 					try {
@@ -348,7 +348,7 @@ public class EventResource extends RestResource<Event> {
 
 			}
 			if (syncData.has("events")) {
-				ArrayList<Event> events = gson.fromJson(syncData.getString("events"),
+				ArrayList<Event> events = gson.fromJson(syncData.getJSONArray("events").toString(),
 				    new TypeToken<ArrayList<Event>>() {}.getType());
 				for (Event event : events) {
 					try {


### PR DESCRIPTION
Adding events is failing due to the following exception encountered when converting the event string to java objects using gson

`Sync data processing failed with exception org.json.JSONException: JSONObject["events"] not a string`