### PR TITLE
Exclude oauth and unprotected endpoints from resource server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.smartregister</groupId>
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.1.41-SNAPSHOT</version>
+	<version>2.1.42-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -25,7 +25,7 @@
 		<opensrp.updatePolicy>always</opensrp.updatePolicy>
 		<nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
 
-		<opensrp.core.version>2.5.14-SNAPSHOT</opensrp.core.version>
+		<opensrp.core.version>2.5.15-SNAPSHOT</opensrp.core.version>
 		<opensrp.connector.version>2.1.2-SNAPSHOT</opensrp.connector.version>
 		<opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
 

--- a/src/main/java/org/opensrp/web/config/security/NotOAuthRequestMatcher.java
+++ b/src/main/java/org/opensrp/web/config/security/NotOAuthRequestMatcher.java
@@ -1,0 +1,43 @@
+/**
+ * 
+ */
+package org.opensrp.web.config.security;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.security.oauth2.provider.endpoint.FrameworkEndpointHandlerMapping;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+
+/**
+ * @author Samuel Githengi created on 07/28/20
+ */
+public class NotOAuthRequestMatcher implements RequestMatcher {
+	
+	private FrameworkEndpointHandlerMapping mapping;
+	
+	public NotOAuthRequestMatcher(FrameworkEndpointHandlerMapping mapping) {
+		this.mapping = mapping;
+	}
+	
+	@Override
+	public boolean matches(HttpServletRequest request) {
+		String requestPath = getRequestPath(request);
+		for (String path : mapping.getPaths()) {
+			if (requestPath.startsWith(mapping.getPath(path))) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	private String getRequestPath(HttpServletRequest request) {
+		String url = request.getServletPath();
+		
+		if (request.getPathInfo() != null) {
+			url += request.getPathInfo();
+		}
+		
+		return url;
+	}
+	
+}

--- a/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
@@ -68,6 +68,8 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
 		        new NotOAuthRequestMatcher(endpoints.oauth2EndpointHandlerMapping()),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("/index.html")),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("/")),
+		        new NegatedRequestMatcher(new AntPathRequestMatcher("/login*")),
+		        new NegatedRequestMatcher(new AntPathRequestMatcher("/logout.do")),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("/**",OPTIONS.name())),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("rest/viewconfiguration/**"))))
 			.authorizeRequests()

--- a/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
@@ -62,18 +62,16 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
 	@Override
 	public void configure(HttpSecurity http) throws Exception {
 		/* @formatter:off */
-		http.cors().configurationSource(corsConfigurationSource)
-		.and()
-			.anonymous().disable()
+		http
 			.requestMatcher(new AndRequestMatcher(new AntPathRequestMatcher("/**"),
 		        new NotOAuthRequestMatcher(endpoints.oauth2EndpointHandlerMapping()),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("/index.html")),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("/")),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("/login*")),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("/logout.do")),
-		        new NegatedRequestMatcher(new AntPathRequestMatcher("/**",OPTIONS.name())),
 		        new NegatedRequestMatcher(new AntPathRequestMatcher("rest/viewconfiguration/**"))))
 			.authorizeRequests()
+				.mvcMatchers(OPTIONS,"/**").permitAll()
 				.mvcMatchers("/rest/*/getAll").hasRole(Role.ALL_EVENTS)
 				.mvcMatchers("/rest/plans/user/**").hasRole(Role.PLANS_FOR_USER)
 				.anyRequest().hasRole(Role.OPENMRS)
@@ -83,6 +81,8 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
 			.httpBasic()
 		.and()
 			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+		.and()
+			.cors().configurationSource(corsConfigurationSource)
 		.and()
 			.authenticationProvider(opensrpAuthenticationProvider);
 		/* @formatter:on */

--- a/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
@@ -3,6 +3,8 @@
  */
 package org.opensrp.web.config.security;
 
+import static org.springframework.http.HttpMethod.OPTIONS;
+
 import org.opensrp.web.config.Role;
 import org.opensrp.web.security.OauthAuthenticationProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,12 +12,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerEndpointsConfiguration;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.error.OAuth2AccessDeniedHandler;
 import org.springframework.security.oauth2.provider.error.OAuth2AuthenticationEntryPoint;
 import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;
+import org.springframework.security.web.util.matcher.AndRequestMatcher;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.web.cors.CorsConfigurationSource;
 
 /**
@@ -38,6 +44,9 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
 	@Autowired
 	private OauthAuthenticationProvider opensrpAuthenticationProvider;
 	
+	@Autowired(required = false)
+	private AuthorizationServerEndpointsConfiguration endpoints;
+	
 	@Override
 	public void configure(ResourceServerSecurityConfigurer security) throws Exception {
 		/* @formatter:off */
@@ -55,8 +64,12 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
 		http.cors().configurationSource(corsConfigurationSource)
 		.and()
 			.anonymous().disable()
-		.requestMatchers().mvcMatchers("/**")
-		.and()
+			.requestMatcher(new AndRequestMatcher(new AntPathRequestMatcher("/**"),
+		        new NotOAuthRequestMatcher(endpoints.oauth2EndpointHandlerMapping()),
+		        new NegatedRequestMatcher(new AntPathRequestMatcher("/index.html")),
+		        new NegatedRequestMatcher(new AntPathRequestMatcher("/")),
+		        new NegatedRequestMatcher(new AntPathRequestMatcher("/**",OPTIONS.name())),
+		        new NegatedRequestMatcher(new AntPathRequestMatcher("rest/viewconfiguration/**"))))
 			.authorizeRequests()
 				.mvcMatchers("/rest/*/getAll").hasRole(Role.ALL_EVENTS)
 				.mvcMatchers("/rest/plans/user/**").hasRole(Role.PLANS_FOR_USER)

--- a/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/security/ResourceServerConfiguration.java
@@ -12,6 +12,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.oauth2.config.annotation.web.configuration.AuthorizationServerEndpointsConfiguration;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
@@ -80,7 +81,10 @@ public class ResourceServerConfiguration extends ResourceServerConfigurerAdapter
 			.exceptionHandling().accessDeniedHandler(accessDeniedHandler())
 		.and()
 			.httpBasic()
-		.and().authenticationProvider(opensrpAuthenticationProvider);
+		.and()
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
+		.and()
+			.authenticationProvider(opensrpAuthenticationProvider);
 		/* @formatter:on */
 	}
 	


### PR DESCRIPTION
- [x] Exclude oauth and unprotected endpoints from resource server

- [x] Oauth endpoints are part of authorization server and should not be included in the resource server.

- [x] Additional endpoints that need to be accessed without authentication have also been removed from the resource server.

- [x] This change necessitates as we have a lot of legacy endpoints that we cannot easily, so this PR is proving functionality to exclude only those endpoints that should not be part of resource server

- [x] Allow session creation for resource server if necessary