### PR TITLE
Get keycloak users to string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.2.23-SNAPSHOT</version>
+	<version>2.2.24-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/rest/UserResource.java
+++ b/src/main/java/org/opensrp/web/rest/UserResource.java
@@ -86,7 +86,7 @@ public class UserResource {
 		uriVariables.put(FIRST, offset);
 		uriVariables.put(MAX, limit);
 		try {
-			response = restTemplate.getForEntity(url, String.class, uriVariables);
+			response = new ResponseEntity<String>(restTemplate.getForObject(url, String.class, uriVariables),HttpStatus.OK);
 		}
 		catch (HttpStatusCodeException e) {
 			return new ResponseEntity<String>(e.getResponseBodyAsString(), e.getStatusCode());

--- a/src/test/java/org/opensrp/web/rest/UserResourceTest.java
+++ b/src/test/java/org/opensrp/web/rest/UserResourceTest.java
@@ -167,21 +167,20 @@ public class UserResourceTest {
 	public void testGetAllKeycloakUsers() throws Exception {
 		String authServer = "http://localhost:8080/auth/";
 		String realm = "opensrp";
-		String url = MessageFormat.format(usersURL, authServer, realm)+"?first={first}&max={max}";
+		String url = MessageFormat.format(usersURL, authServer, realm) + "?first={first}&max={max}";
 		when(keycloakDeployment.getAuthServerBaseUrl()).thenReturn(authServer);
 		when(keycloakDeployment.getRealm()).thenReturn(realm);
 		Map<String, Object> uriVariables = new HashMap<>();
 		uriVariables.put("first", 0);
 		uriVariables.put("max", 100);
 		String expected = "[{\"id\":\"wewql9abe70ad66\",\"createdTimestamp\":1595352823770,\"username\":\"campdemo1\",\"enabled\":true,\"totp\":false,\"emailVerified\":false,\"firstName\":\"Abimbola\",\"lastName\":\"Phillips\"}]";
-		doReturn(new ResponseEntity<String>(expected, HttpStatus.OK)).when(restTemplate).getForEntity(url, String.class,
-		    uriVariables);
+		doReturn(expected).when(restTemplate).getForObject(url, String.class, uriVariables);
 		Whitebox.setInternalState(userResource, "restTemplate", restTemplate);
 		MvcResult response = mockMvc
 		        .perform(
 		            get(BASE_URL).param("page_size", "100").param("start_index", "0").param("source", UserResource.KEYCLOAK))
 		        .andExpect(status().isOk()).andReturn();
-		verify(restTemplate).getForEntity(url, String.class, uriVariables);
+		verify(restTemplate).getForObject(url, String.class, uriVariables);
 		assertEquals(expected, response.getResponse().getContentAsString());
 		
 	}


### PR DESCRIPTION
- [x] Returning ResponseEntity from restTemplate is returning black if users exceed 28.

- [x] This is to make sure all the users are returned even for large page sizes