### PR TITLE
Server version changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.4.9-SNAPSHOT</version>
+	<version>2.4.10-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -26,7 +26,7 @@
 		<redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
 		<opensrp.updatePolicy>always</opensrp.updatePolicy>
 		<nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-		<opensrp.core.version>2.8.11-SNAPSHOT</opensrp.core.version>
+		<opensrp.core.version>2.8.13-SNAPSHOT</opensrp.core.version>
 		<opensrp.connector.version>2.2.0-SNAPSHOT</opensrp.connector.version>
 		<opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
 		<opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>

--- a/src/test/java/org/opensrp/web/rest/SettingResourceTest.java
+++ b/src/test/java/org/opensrp/web/rest/SettingResourceTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
-import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -222,7 +221,7 @@ public class SettingResourceTest {
 	public void testPostSaveSetting() throws Exception {
 		String SETTINGS_JSON = "{\"settingConfigurations\":[\"Client1\"]}";
 
-		when(settingService.saveSetting(Matchers.any(String.class))).thenReturn("ID-12345");
+		when(settingService.saveSetting(any(String.class))).thenReturn("ID-12345");
 		MvcResult mvcResult = this.mockMvc.perform(
 				post(BASE_URL + "/sync").contentType(MediaType.APPLICATION_JSON).content(SETTINGS_JSON.getBytes())
 						.accept(MediaType.APPLICATION_JSON))
@@ -267,7 +266,6 @@ public class SettingResourceTest {
 
 		verify(settingRepository, Mockito.times(1)).addSettings(settingConfigurationArgumentCaptor.capture());
 		verify(settingRepository, Mockito.times(1)).get(documentId);
-		verify(settingRepository).getNextServerVersion();
 		verifyNoMoreInteractions(settingRepository);
 	}
 
@@ -290,7 +288,6 @@ public class SettingResourceTest {
 
 		verify(settingRepository, Mockito.times(1)).get(documentId);
 		verify(settingRepository, Mockito.times(1)).update(settingConfigurationArgumentCaptor.capture());
-		verify(settingRepository).getNextServerVersion();
 		verifyNoMoreInteractions(settingRepository);
 	}
 


### PR DESCRIPTION
Server version Changes

- [x] Generate server version on insert and update clauses
- [x] Make insert or update atomic using transactions on repositories
- [x] Raise errors instead of returning null when insert or update fails or any other error occurs
