### PR TITLE
Default locationId search from intersection of plan locations and organization assigned locations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.4.21-SNAPSHOT</version>
+	<version>2.4.22-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/controller/UserController.java
+++ b/src/main/java/org/opensrp/web/controller/UserController.java
@@ -246,6 +246,7 @@ public class UserController {
 		teamMemberJson.put("uuid", practionerOrganizationIds.left.getUserId());
 		
 		JSONObject teamJson = new JSONObject();
+		JSONObject teamLocationJson = new JSONObject();
 		// TODO populate organizations if user has many organizations
 		Organization organization = organizationService.getOrganization(practionerOrganizationIds.right.get(0));
 		teamJson.put("teamName", organization.getName());
@@ -256,25 +257,28 @@ public class UserController {
 		JSONArray locations = new JSONArray();
 		
 		/** @formatter:off*/
-		PhysicalLocation defaultLocationId = jurisdictions
+		String defaultLocationId = jurisdictions
 				.stream()
 				.filter(j -> locationIds.contains(j.getId()))
 				.findFirst()
-				.get();
+				.get().getId();
 		/** @formatter:on*/
 		
 		Set<String> locationParents = new HashSet<>();
 		for (PhysicalLocation jurisdiction : jurisdictions) {
-			JSONObject teamLocation = new JSONObject();
-			teamLocation.put("uuid",defaultLocationId);
-			teamLocation.put("name", jurisdiction.getProperties().getName());
-			teamLocation.put("display", jurisdiction.getProperties().getName());
-			locations.put(teamLocation);
+			JSONObject locationJson = new JSONObject();
+			locationJson.put("uuid",jurisdiction.getId());
+			locationJson.put("name", jurisdiction.getProperties().getName());
+			locationJson.put("display", jurisdiction.getProperties().getName());
+			locations.put(locationJson);
 			locationParents.add(jurisdiction.getProperties().getParentId());
+			if(jurisdiction.getId().equals(defaultLocationId)) {
+				teamLocationJson=locationJson;
+			}
 		}
 		
 		//team location is still returned as 1 object
-		teamJson.put("location", locations.getJSONObject(0));
+		teamJson.put("location", teamLocationJson);
 		teamMemberJson.put("locations", locations);
 		teamMemberJson.put("team", teamJson);
 		

--- a/src/main/java/org/opensrp/web/controller/UserController.java
+++ b/src/main/java/org/opensrp/web/controller/UserController.java
@@ -193,7 +193,7 @@ public class UserController {
 		User u = RestUtils.currentUser(authentication);
 		logger.debug("logged in user {}", u.toString());
 		ImmutablePair<Practitioner, List<Long>> practionerOrganizationIds = null;
-		Set<PhysicalLocation> jurisdictions = null;
+		final Set<PhysicalLocation> jurisdictions =  new HashSet<>();
 		Set<String> locationIds = new HashSet<>();
 		Set<String> planIdentifiers = new HashSet<>();
 		try {
@@ -208,7 +208,7 @@ public class UserController {
 					planIdentifiers.add(assignedLocation.getPlanId());
 			}
 			
-			jurisdictions = new HashSet<>(locationService.findLocationByIdsWithChildren(false, locationIds, Integer.MAX_VALUE));
+			jurisdictions.addAll(locationService.findLocationByIdsWithChildren(false, locationIds, Integer.MAX_VALUE));
 			
 			if (!planIdentifiers.isEmpty()) {
 				/** @formatter:off*/
@@ -255,10 +255,18 @@ public class UserController {
 		
 		JSONArray locations = new JSONArray();
 		
+		/** @formatter:off*/
+		PhysicalLocation defaultLocationId = jurisdictions
+				.stream()
+				.filter(j -> locationIds.contains(j.getId()))
+				.findFirst()
+				.get();
+		/** @formatter:on*/
+		
 		Set<String> locationParents = new HashSet<>();
 		for (PhysicalLocation jurisdiction : jurisdictions) {
 			JSONObject teamLocation = new JSONObject();
-			teamLocation.put("uuid", locationIds.iterator().next());
+			teamLocation.put("uuid",defaultLocationId);
 			teamLocation.put("name", jurisdiction.getProperties().getName());
 			teamLocation.put("display", jurisdiction.getProperties().getName());
 			locations.put(teamLocation);

--- a/src/test/java/org/opensrp/web/rest/UserControllerTest.java
+++ b/src/test/java/org/opensrp/web/rest/UserControllerTest.java
@@ -202,6 +202,7 @@ public class UserControllerTest {
 		
 		PhysicalLocation location = LocationResourceTest.createStructure();
 		location.getProperties().setName("OA123");
+		location.setId(jurisdictionId);
 		when(locationService.findLocationByIdsWithChildren(false, Collections.singleton(jurisdictionId), Integer.MAX_VALUE))
 		        .thenReturn(Collections.singletonList(location));
 		when(locationService.buildLocationHierachy(Collections.singleton(location.getId()), false, true))


### PR DESCRIPTION
There are circumstances where the default locationId returned by the API belonged to  a team assignment whose plan is not currently active (e.g retired). 
This would lead to the android client not being able to populate the location drop-down resulting in an `Error Processing Location Hierarchy. Log off to download location hierarchy again` error.