### PR TITLE
Resolve `release file overriding previous releases`

### DIFF
--- a/src/main/java/org/opensrp/web/rest/ClientFormResource.java
+++ b/src/main/java/org/opensrp/web/rest/ClientFormResource.java
@@ -49,7 +49,7 @@ public class ClientFormResource {
 
     public static final String FORMS_VERSION = "forms_version";
 
-    private static Logger logger = LogManager.getLogger(EventResource.class.toString());
+    private static Logger logger = LogManager.getLogger(ClientFormResource.class.toString());
     protected ObjectMapper objectMapper;
     private ClientFormService clientFormService;
     private ManifestService manifestService;

--- a/src/main/java/org/opensrp/web/rest/ClientFormResource.java
+++ b/src/main/java/org/opensrp/web/rest/ClientFormResource.java
@@ -174,29 +174,29 @@ public class ClientFormResource {
         List<ClientFormMetadata> clientFormMetadataList = new ArrayList<>();
 
         Manifest manifest = manifestService.getManifest(releaseIdentifier);
-        if (manifest != null && StringUtils.isNotBlank(manifest.getJson())) {
-            JSONObject json = new JSONObject(manifest.getJson());
-            if (json.has(FORM_IDENTIFIERS)) {
-                JSONArray fileIdentifiers = json.getJSONArray(FORM_IDENTIFIERS);
-                if (fileIdentifiers != null && fileIdentifiers.length() > 0) {
-                    for (int i = 0; i < fileIdentifiers.length(); i++) {
-                        String fileIdentifier = fileIdentifiers.getString(i);
-                        ClientFormMetadata clientFormMetadata = getMostRecentVersion(fileIdentifier, false);
-                        if (clientFormMetadata != null) {
-                            clientFormMetadataList.add(clientFormMetadata);
-                        }
-                    }
-                } else {
-                    return new ResponseEntity<>("This manifest does not have any files related to it",
-                                HttpStatus.NO_CONTENT);
-                }
-            } else {
-                return new ResponseEntity<>("This manifest does not have any files related to it",
-                       HttpStatus.NO_CONTENT);
-            }
-        } else {
+        if (manifest == null || StringUtils.isBlank(manifest.getJson())){
             return new ResponseEntity<>("This manifest does not have any files related to it",
                     HttpStatus.NOT_FOUND);
+        }
+
+        JSONObject json = new JSONObject(manifest.getJson());
+        if (!json.has(FORM_IDENTIFIERS)){
+            return new ResponseEntity<>("This manifest does not have any files related to it",
+                    HttpStatus.NO_CONTENT);
+        }
+
+        JSONArray fileIdentifiers = json.getJSONArray(FORM_IDENTIFIERS);
+        if (fileIdentifiers == null || fileIdentifiers.length() <= 0){
+            return new ResponseEntity<>("This manifest does not have any files related to it",
+                    HttpStatus.NO_CONTENT);
+        }
+
+        for (int i = 0; i < fileIdentifiers.length(); i++) {
+            String fileIdentifier = fileIdentifiers.getString(i);
+            ClientFormMetadata clientFormMetadata = getMostRecentVersion(fileIdentifier, false);
+            if (clientFormMetadata != null) {
+                clientFormMetadataList.add(clientFormMetadata);
+            }
         }
 
         return new ResponseEntity<>(objectMapper.writeValueAsString(clientFormMetadataList.toArray(new ClientFormMetadata[0])), HttpStatus.OK);

--- a/src/main/java/org/opensrp/web/rest/ClientFormResource.java
+++ b/src/main/java/org/opensrp/web/rest/ClientFormResource.java
@@ -142,10 +142,10 @@ public class ClientFormResource {
         return new ResponseEntity<>(objectMapper.writeValueAsString(completeClientForm), HttpStatus.OK);
     }
 
-    private final Comparator<IdVersionTuple> idVersionTupleComparator = (o1, o2) -> {
-        final DefaultArtifactVersion o1ArtifactVersion = new DefaultArtifactVersion(o1.getVersion());
-        final DefaultArtifactVersion o2ArtifactVersion = new DefaultArtifactVersion(o2.getVersion());
-        return o1ArtifactVersion.compareTo(o2ArtifactVersion);
+    private final Comparator<IdVersionTuple> idVersionTupleByVersionComparator = (o1, o2) -> {
+        final DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(o1.getVersion());
+        final DefaultArtifactVersion otherArtifactVersion = new DefaultArtifactVersion(o2.getVersion());
+        return artifactVersion.compareTo(otherArtifactVersion);
     };
 
     private ClientFormMetadata getMostRecentWithVersion(@NonNull final String formIdentifier, final boolean isJsonValidator, @Nullable final String formVersionCap){
@@ -158,7 +158,7 @@ public class ClientFormResource {
                         final DefaultArtifactVersion artifactVersion = new DefaultArtifactVersion(idVersionTuple.getVersion());
                         return artifactVersion.compareTo(artifactVersionCap) <= 0;
                     })
-                    .max(idVersionTupleComparator);
+                    .max(idVersionTupleByVersionComparator);
         } else {
             maxInCapLimitIdVersionTuple = Optional.empty();
         }
@@ -166,7 +166,7 @@ public class ClientFormResource {
         final Optional<IdVersionTuple> maxNoCap;
         if (maxInCapLimitIdVersionTuple.isEmpty()) {
             maxNoCap = availableFormIdVersions.stream()
-                    .max(idVersionTupleComparator);
+                    .max(idVersionTupleByVersionComparator);
         } else {
             maxNoCap = Optional.empty();
         }


### PR DESCRIPTION
Resolves #801 
Resolves OpenSRP/opensrp-client-anc#552

Get expected file version from manifest
For each file in a manifest release
- Check for version matching version from manifest `or` highest version below version from manifest 
- if not found, checks for the highest, most recent version