### PR TITLE
make revoking team assignments for complete/retired plans optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.15-SNAPSHOT</version>
+    <version>2.8.16-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -25,7 +25,7 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.12.2-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.12.4-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.3.0-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>

--- a/src/main/java/org/opensrp/web/rest/PlanResource.java
+++ b/src/main/java/org/opensrp/web/rest/PlanResource.java
@@ -77,6 +77,8 @@ public class PlanResource {
 
 	private static final String FALSE = "false";
 
+	private static final String TRUE = "true";
+
 	public static final String OPERATIONAL_AREA_ID = "operational_area_id";
 	
 	public static final String IDENTIFIERS = "identifiers";
@@ -86,6 +88,8 @@ public class PlanResource {
 	public static final String USERNAME = "username";
 
 	public static final String IS_TEMPLATE = "is_template";
+
+	public static final String REVOKE_ASSIGNMENTS = "revoke_assignments";
 
 	public static final String PLAN_STATUS = "planStatus";
 
@@ -159,12 +163,13 @@ public class PlanResource {
 		}
 
 	}
-	
+
 	@RequestMapping(method = RequestMethod.PUT, consumes = { MediaType.APPLICATION_JSON_VALUE, MediaType.TEXT_PLAIN_VALUE })
-	public ResponseEntity<HttpStatus> update(@RequestBody String entity, Authentication authentication) {
+	public ResponseEntity<HttpStatus> update(@RequestBody String entity, Authentication authentication,
+			@RequestParam(value = REVOKE_ASSIGNMENTS, defaultValue = TRUE, required = false) boolean revokeAssignments) {
 		try {
 			PlanDefinition plan = gson.fromJson(entity, PlanDefinition.class);
-			planService.updatePlan(plan, RestUtils.currentUser(authentication).getUsername());
+			planService.updatePlan(plan, RestUtils.currentUser(authentication).getUsername(), revokeAssignments);
 			return new ResponseEntity<>(HttpStatus.CREATED);
 		}
 		catch (JsonSyntaxException e) {


### PR DESCRIPTION
using 'revoke_assignments' parameter

closes #905 