### PR TITLE
Add timeout for health indicators v2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Status Code: 200
     "keycloak": true,
     "rabbitmq": true
   },
-  "serverTime": "2021-11-02T09:44:43.584+03:00",
+  "serverTime": "2021-11-01T09:44:43.584+03:00",
   "buildVersion": "3.2"
 }
 ```
@@ -87,4 +87,15 @@ Status Code: 503
   "buildVersion": "3.2"
 }
 ```
+
+#### Configurations for the Endpoint
+
+| Configuration                               | Description                                    | Type    | Default | 
+|---------------------------------------------|------------------------------------------------|---------|---------|
+| health.endpoint.keycloak.connectionTimeout  | http client connection timeout for the request | Integer | 5000ms  |
+| health.endpoint.keycloak.readTimeout        | http client read timeout for the request       | Integer | 5000ms  |
+| health.endpoint.postgres.queryTimeout       | postgres query timeout for indicator DB query  | Integer | 2000ms  |
+
+The above configs can be updated on `opensrp.properties` file.  
+
 **NOTE: Some services will only be checked if they are enabled by the spring maven profiles e.g rabbitmq**

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.29-SNAPSHOT</version>
+    <version>2.8.30-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/health/JdbcServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/health/JdbcServiceHealthIndicator.java
@@ -5,10 +5,12 @@ import org.apache.logging.log4j.Logger;
 import org.opensrp.web.Constants;
 import org.opensrp.web.contract.ServiceHealthIndicator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.ModelMap;
+import javax.sql.DataSource;
 
 import java.util.concurrent.Callable;
 
@@ -18,8 +20,11 @@ public class JdbcServiceHealthIndicator implements ServiceHealthIndicator {
 
 	private static final Logger logger = LogManager.getLogger(JdbcServiceHealthIndicator.class.toString());
 
+	@Value("#{opensrp['health.endpoint.postgres.queryTimeout'] ?: 2000 }")
+	private Integer queryTimeout;
+
 	@Autowired
-	private JdbcTemplate jdbcTemplate;
+	private DataSource dataSource;
 
 	private final String HEALTH_INDICATOR_KEY = "postgres";
 
@@ -29,6 +34,8 @@ public class JdbcServiceHealthIndicator implements ServiceHealthIndicator {
 			ModelMap modelMap = new ModelMap();
 			boolean result = false;
 			try {
+				JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+				jdbcTemplate.setQueryTimeout(queryTimeout);
 				result = jdbcTemplate.queryForObject("SELECT 1;", Integer.class) == 1;
 			}
 			catch (Exception e) {

--- a/src/test/java/org/opensrp/TestDatabaseConfig.java
+++ b/src/test/java/org/opensrp/TestDatabaseConfig.java
@@ -3,7 +3,8 @@ package org.opensrp;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.jdbc.core.JdbcTemplate;
+
+import javax.sql.DataSource;
 
 import static org.mockito.Mockito.mock;
 
@@ -11,8 +12,8 @@ import static org.mockito.Mockito.mock;
 public class TestDatabaseConfig {
 
     @Bean
-    public JdbcTemplate jdbcTemplate() {
-        return mock(JdbcTemplate.class);
+    public DataSource dataSource() {
+        return mock(DataSource.class);
     }
 
     @Bean

--- a/src/test/java/org/opensrp/web/health/JdbcServiceHealthIndicatorTest.java
+++ b/src/test/java/org/opensrp/web/health/JdbcServiceHealthIndicatorTest.java
@@ -6,15 +6,17 @@ import org.opensrp.web.Constants;
 import org.opensrp.web.rest.it.TestWebContextLoader;
 import org.powermock.reflect.Whitebox;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.ui.ModelMap;
 
+import javax.sql.DataSource;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = TestWebContextLoader.class, locations = { "classpath:test-webmvc-config.xml", })
@@ -26,8 +28,8 @@ public class JdbcServiceHealthIndicatorTest {
 
 	@Test
 	public void testDoHealthCheckShouldReturnValidMap() throws Exception {
-		JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
-		Whitebox.setInternalState(jdbcServiceHealthIndicator, "jdbcTemplate", jdbcTemplate);
+		DataSource dataSource = mock(DataSource.class);
+		Whitebox.setInternalState(jdbcServiceHealthIndicator, "dataSource", dataSource);
 		ModelMap map = jdbcServiceHealthIndicator.doHealthCheck().call();
 		assertNotNull(map);
 		assertTrue(map.containsKey(Constants.HealthIndicator.EXCEPTION));


### PR DESCRIPTION
Add timeouts for postgres `2s`  and Keycloak `5s` indicators. This ensures that endpoint returns a response at ~5s at the most.