### PR TITLE
Add timeout for health indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,4 +88,14 @@ Status Code: 503
 }
 ```
 
+#### Configurations for the Endpoint
+
+| Configuration                               | Description                                    | Type    | Default | 
+|---------------------------------------------|------------------------------------------------|---------|---------|
+| health.endpoint.openmrs.connectionTimeout   | http client connection timeout for the request | Integer | 5000ms  |
+| health.endpoint.openmrs.readTimeout         | http client read timeout for the request       | Integer | 5000ms  |
+| health.endpoint.postgres.queryTimeout       | postgres query timeout for indicator DB query  | Integer | 2000ms  |
+
+The above configs can be updated on `opensrp.properties` file.  
+
 **NOTE: Some services will only be checked if they are enabled by the spring maven profiles e.g rabbitmq**

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.smartregister</groupId>
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.1.53.5-SNAPSHOT</version>
+	<version>2.1.53.6-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/health/JdbcServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/health/JdbcServiceHealthIndicator.java
@@ -5,10 +5,12 @@ import org.apache.logging.log4j.Logger;
 import org.opensrp.web.Constants;
 import org.opensrp.web.contract.ServiceHealthIndicator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.ModelMap;
+import javax.sql.DataSource;
 
 import java.util.concurrent.Callable;
 
@@ -18,8 +20,11 @@ public class JdbcServiceHealthIndicator implements ServiceHealthIndicator {
 
 	private static final Logger logger = LogManager.getLogger(JdbcServiceHealthIndicator.class.toString());
 
+	@Value("#{opensrp['health.endpoint.postgres.queryTimeout'] ?: 2000 }")
+	private Integer queryTimeout;
+
 	@Autowired
-	private JdbcTemplate jdbcTemplate;
+	private DataSource dataSource;
 
 	private final String HEALTH_INDICATOR_KEY = "postgres";
 
@@ -29,6 +34,8 @@ public class JdbcServiceHealthIndicator implements ServiceHealthIndicator {
 			ModelMap modelMap = new ModelMap();
 			boolean result = false;
 			try {
+				JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+				jdbcTemplate.setQueryTimeout(queryTimeout);
 				result = jdbcTemplate.queryForObject("SELECT 1;", Integer.class) == 1;
 			}
 			catch (Exception e) {

--- a/src/main/java/org/opensrp/web/health/OpenmrsServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/health/OpenmrsServiceHealthIndicator.java
@@ -7,6 +7,7 @@ import org.opensrp.web.contract.ServiceHealthIndicator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.client.RestTemplate;
@@ -21,6 +22,12 @@ public class OpenmrsServiceHealthIndicator implements ServiceHealthIndicator {
 	@Value("#{opensrp['openmrs.url'] ?: ''}")
 	private String openmrsUrl;
 
+	@Value("#{opensrp['health.endpoint.openmrs.connectionTimeout'] ?: 5000 }")
+	private Integer openmrsConnectionTimeout;
+
+	@Value("#{opensrp['health.endpoint.openmrs.readTimeout'] ?: 5000 }")
+	private Integer openmrsReadTimeout;
+
 	private final String HEALTH_INDICATOR_KEY = "openmrs";
 
 	@Override
@@ -29,7 +36,11 @@ public class OpenmrsServiceHealthIndicator implements ServiceHealthIndicator {
 			ModelMap modelMap = new ModelMap();
 			boolean result = false;
 			try {
-				RestTemplate restTemplate = new RestTemplate();
+				SimpleClientHttpRequestFactory simpleClientHttpRequestFactory = new SimpleClientHttpRequestFactory();
+				simpleClientHttpRequestFactory.setConnectTimeout(openmrsConnectionTimeout);
+				simpleClientHttpRequestFactory.setReadTimeout(openmrsReadTimeout);
+
+				RestTemplate restTemplate = new RestTemplate(simpleClientHttpRequestFactory);
 				ResponseEntity<String> responseEntity = restTemplate.getForEntity(openmrsUrl,
 						String.class);
 				result = responseEntity.getStatusCode() == HttpStatus.OK;

--- a/src/test/java/org/opensrp/web/health/JdbcServiceHealthIndicatorTest.java
+++ b/src/test/java/org/opensrp/web/health/JdbcServiceHealthIndicatorTest.java
@@ -6,15 +6,17 @@ import org.opensrp.web.Constants;
 import org.opensrp.web.rest.it.TestWebContextLoader;
 import org.powermock.reflect.Whitebox;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.ui.ModelMap;
 
+import javax.sql.DataSource;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;import static org.mockito.Mockito.mock;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = TestWebContextLoader.class, locations = { "classpath:test-webmvc-config.xml", })
@@ -26,8 +28,8 @@ public class JdbcServiceHealthIndicatorTest {
 
 	@Test
 	public void testDoHealthCheckShouldReturnValidMap() throws Exception {
-		JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
-		Whitebox.setInternalState(jdbcServiceHealthIndicator, "jdbcTemplate", jdbcTemplate);
+		DataSource dataSource = mock(DataSource.class);
+		Whitebox.setInternalState(jdbcServiceHealthIndicator, "dataSource", dataSource);
 		ModelMap map = jdbcServiceHealthIndicator.doHealthCheck().call();
 		assertNotNull(map);
 		assertTrue(map.containsKey(Constants.HealthIndicator.EXCEPTION));


### PR DESCRIPTION
Add timeouts for postgres `2s`  and openmrs `5s` indicators. This ensures that endpoint returns a response at ~5s at the most.