### PR TITLE
add opensrp server metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,63 @@
 # opensrp-server-web
-[![Build Status](https://travis-ci.org/OpenSRP/opensrp-server-web.svg?branch=master)](https://travis-ci.org/OpenSRP/opensrp-server-web) [![Coverage Status](https://coveralls.io/repos/github/OpenSRP/opensrp-server-web/badge.svg?branch=master)](https://coveralls.io/github/OpenSRP/opensrp-server-web?branch=master) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5544ce1a89924b919197c902819c83eb)](https://www.codacy.com/app/OpenSRP/opensrp-server-web?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=OpenSRP/opensrp-server-web&amp;utm_campaign=Badge_Grade)
 
-## Overview 
+[![Build Status](https://travis-ci.org/OpenSRP/opensrp-server-web.svg?branch=master)](https://travis-ci.org/OpenSRP/opensrp-server-web) [![Coverage Status](https://coveralls.io/repos/github/OpenSRP/opensrp-server-web/badge.svg?branch=master)](https://coveralls.io/github/OpenSRP/opensrp-server-web?branch=master) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5544ce1a89924b919197c902819c83eb)](https://www.codacy.com/app/OpenSRP/opensrp-server-web?utm\_source=github.com\&utm\_medium=referral\&utm\_content=OpenSRP/opensrp-server-web\&utm\_campaign=Badge\_Grade)
+
+## Overview
+
 Generic web application
 
 ### Relevant Wiki Pages
-* OpenSRP Server Refactor and Cleanup
-  * [Refactor and Cleanup](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/562659330/OpenSRP+Server+Refactor+and+Clean+up)
-  * [How to upload and use maven jar artifacts](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/564428801/How+to+upload+and+use+maven+jar+artifacts)
-  * [Managing Server Wide Properties](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/602570753/Managing+Server+Wide+Properties)
-  * [Server Web Build](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/616595457/Server+Web+Build)
-* [OpenSRP Server Build](https://smartregister.atlassian.net/wiki/display/Documentation/OpenSRP+Server+Build)
-* Deployment
-  * [Docker Setup](https://smartregister.atlassian.net/wiki/display/Documentation/Docker+Setup)
-  * [Docker Compose Setup](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/52690976/Docker+Compose+Setup)
-  * [Ansible Playbooks](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/540901377/Ansible+Playbooks)
-* [Postgres Database Support](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/251068417/Postgres+Database+Support+as+Main+Datastore)
-* [OpenSRP Load Testing](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/268075009/OpenSRP+Load+Testing)
 
-**Date/Time Filters** 
+*   OpenSRP Server Refactor and Cleanup
+    *   [Refactor and Cleanup](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/562659330/OpenSRP+Server+Refactor+and+Clean+up)
+    *   [How to upload and use maven jar artifacts](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/564428801/How+to+upload+and+use+maven+jar+artifacts)
+    *   [Managing Server Wide Properties](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/602570753/Managing+Server+Wide+Properties)
+    *   [Server Web Build](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/616595457/Server+Web+Build)
+*   [OpenSRP Server Build](https://smartregister.atlassian.net/wiki/display/Documentation/OpenSRP+Server+Build)
+*   Deployment
+    *   [Docker Setup](https://smartregister.atlassian.net/wiki/display/Documentation/Docker+Setup)
+    *   [Docker Compose Setup](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/52690976/Docker+Compose+Setup)
+    *   [Ansible Playbooks](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/540901377/Ansible+Playbooks)
+*   [Postgres Database Support](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/251068417/Postgres+Database+Support+as+Main+Datastore)
+*   [OpenSRP Load Testing](https://smartregister.atlassian.net/wiki/spaces/Documentation/pages/268075009/OpenSRP+Load+Testing)
+
+**Date/Time Filters**
 Endpoints supporting date/time filters have the following optional parameters  `fromDate` and `toDate` support [DateTimeFormat.ISO](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/format/annotation/DateTimeFormat.ISO.html "enum in org.springframework.format.annotation") i.e `yyyy-MM-dd'T'HH:mm:ss.SSSXXX` and unix timestamp with millisecond precision
- * yyyy - year
- * MM - month
- * dd - date
- * 'T' string literal
- * HH - hour
- * mm - minute
- * ss - seconds
- * SSS - milliseconds
- * XXX - ISO 8601 time zone
 
-e.g`` 2020-10-10T19:32:13.856Z``, ``2020-10-10T19:32``, ``2020-10-10T19:32:56.235+07:00``
+*   yyyy - year
+*   MM - month
+*   dd - date
+*   'T' string literal
+*   HH - hour
+*   mm - minute
+*   ss - seconds
+*   SSS - milliseconds
+*   XXX - ISO 8601 time zone
+
+e.g` 2020-10-10T19:32:13.856Z`, `2020-10-10T19:32`, `2020-10-10T19:32:56.235+07:00`
 Sample Request
 
-``/opensrp/rest/event/findIdsByEventType?fromDate=2000-10-31T01:30&serverVersion=0``
+`/opensrp/rest/event/findIdsByEventType?fromDate=2000-10-31T01:30&serverVersion=0`
 
-``/opensrp/rest/event/findIdsByEventType?fromDate=1602068945000&serverVersion=0``
+`/opensrp/rest/event/findIdsByEventType?fromDate=1602068945000&serverVersion=0`
 
-``/opensrp/rest/event/findIdsByEventType?fromDate=2000-10-31T01:30&serverVersion=0``
+`/opensrp/rest/event/findIdsByEventType?fromDate=2000-10-31T01:30&serverVersion=0`
 
-``/opensrp/rest/event/findIdsByEventType?fromDate=2000-10-31T01:30:00.000%2B05:00&serverVersion=0``
+`/opensrp/rest/event/findIdsByEventType?fromDate=2000-10-31T01:30:00.000%2B05:00&serverVersion=0`
 
-**NOTE:** 
+**NOTE:**
 Remember to add your timezone to the DateTimeFormat.ISO
 
 ### Health Endpoint
+
 The health endpoint of the opensrp server is `/opensrp/health`. It always returns information in JSON format. The status code of the response can either be `200` or `503` depending on status of the services. Response status code is `200` if all the services are running ok but `503` if any service is down/inaccessible.
 
 Sample responses from the health endpoint are as follows:
 
-Request Endpoint: `/opensrp/health`  
-Request Method: GET  
-Status Code: 200  
+Request Endpoint: `/opensrp/health`\
+Request Method: GET\
+Status Code: 200
+
 ```json
 {
   "problems": {},
@@ -66,11 +72,12 @@ Status Code: 200
 }
 ```
 
----
+***
 
-Request Endpoint: `/opensrp/health`  
-Request Method: GET  
-Status Code: 503  
+Request Endpoint: `/opensrp/health`\
+Request Method: GET\
+Status Code: 503
+
 ```json
 {
   "problems": {
@@ -88,32 +95,34 @@ Status Code: 503
 }
 ```
 
-#### Configurations for the Endpoint
+#### Configurations for the health endpoint
 
-| Configuration                               | Description                                    | Type    | Default | 
+| Configuration                               | Description                                    | Type    | Default |
 |---------------------------------------------|------------------------------------------------|---------|---------|
 | health.endpoint.keycloak.connectionTimeout  | http client connection timeout for the request | Integer | 5000ms  |
 | health.endpoint.keycloak.readTimeout        | http client read timeout for the request       | Integer | 5000ms  |
 | health.endpoint.postgres.queryTimeout       | postgres query timeout for indicator DB query  | Integer | 2000ms  |
 
-The above configs can be updated on `opensrp.properties` file.  
+The above configs can be updated on `opensrp.properties` file.
 
 **NOTE: Some services will only be checked if they are enabled by the spring maven profiles e.g rabbitmq**
 
-
 ### Metrics Endpoint
-The metrics endpoint of the opensrp server is `/opensrp/metrics`. It returns information in `text/plain; version=0.0.4; charset=utf-8` format. The status code of the response should always be `200`.  
+
+The metrics endpoint of the opensrp server is `/opensrp/metrics`. It returns information in `text/plain; version=0.0.4; charset=utf-8` format. The status code of the response should always be `200`.
 
 The endpoint is only accessible through the following ips when unauthenticated but requires authentication for the any other ips:
-- `127.0.0.1`, 
-- `InetAddress.getLocalHost().getHostAddress()`,
-- One additional configurable ip, kindly check below `metrics.additional_ip_allowed`
+
+*   `127.0.0.1`,
+*   `InetAddress.getLocalHost().getHostAddress()`,
+*   One additional configurable ip, kindly check below `metrics.additional_ip_allowed`
 
 Sample responses from the metrics endpoint are as follows:
 
-Request Endpoint: `/opensrp/health`  
-Request Method: GET  
+Request Endpoint: `/opensrp/health`\
+Request Method: GET\
 Status Code: 200
+
 ```text
 # HELP health_check_rabbitmq  
 # TYPE health_check_rabbitmq gauge
@@ -127,13 +136,13 @@ health_check_postgres 1.0
 jvm_threads_states_threads{state="blocked",} 0.0
 ```
 
-#### Configurations for the Endpoint
+#### Configurations for the metrics endpoint
 
-| Configuration                               | Description                                    | Type    | Default | 
+| Configuration                               | Description                                    | Type    | Default |
 |---------------------------------------------|------------------------------------------------|---------|---------|
 | metrics.tags  | Refers to the common tags to be added on all metrics | Map | {}  |
-| metrics.health_check_updater.cron        | Cron schedule for updating health indicator (custom metrics)      | Integer | 1minute  |
-| metrics.additional_ip_allowed       | ip or pattern for access metrics endpoint without authentication e.g  192.168.100.0/8 or 192.168.100.3 (only one ip) | String | ""  |
+| metrics.health\_check\_updater.cron        | Cron schedule for updating health indicator (custom metrics)      | Integer | 1minute  |
+| metrics.additional\_ip\_allowed       | ip or pattern for access metrics endpoint without authentication e.g  192.168.100.0/8 or 192.168.100.3 (only one ip) | String | ""  |
 | metrics.include       | metrics to be include  | Set (Comma separated string) | "all"  |
 | metrics.exclude       | metrics to be excluded  | Set (Comma separated string) | ""  |
 | metrics.permitAll       | permits access to metrics endpoint without authentication (Set true if restriction on reverse proxy configs, otherwise whitelist ip if needed) | Boolean | false  |
@@ -141,6 +150,6 @@ jvm_threads_states_threads{state="blocked",} 0.0
 > Available metrics:
 > `all,log4j2,jvm_thread,jvm_thread,jvm_gc,jvm_mem,cpu,uptime,db,disk_space`
 
-> Health indicators [above](#health-endpoint) are added as gauge meters with name in the following pattern; health_check_%s, `%s` is a placeholder for service name e.g health_check_postgres 
+> Health indicators [above](#health-endpoint) are added as gauge meters with name in the following pattern; health\_check\_%s, `%s` is a placeholder for service name e.g health\_check\_postgres
 
 The above configs can be updated on `opensrp.properties` file.

--- a/README.md
+++ b/README.md
@@ -99,3 +99,47 @@ Status Code: 503
 The above configs can be updated on `opensrp.properties` file.  
 
 **NOTE: Some services will only be checked if they are enabled by the spring maven profiles e.g rabbitmq**
+
+
+### Metrics Endpoint
+The metrics endpoint of the opensrp server is `/opensrp/metrics`. It returns information in `text/plain; version=0.0.4; charset=utf-8` format. The status code of the response should always be `200`.  
+
+The endpoint is only accessible through the following ips when unauthenticated but requires authentication for the any other ips:
+- `127.0.0.1`, 
+- `InetAddress.getLocalHost().getHostAddress()`,
+- One additional configurable ip, kindly check below `metrics.additional_ip_allowed`
+
+Sample responses from the metrics endpoint are as follows:
+
+Request Endpoint: `/opensrp/health`  
+Request Method: GET  
+Status Code: 200
+```text
+# HELP health_check_rabbitmq  
+# TYPE health_check_rabbitmq gauge
+health_check_rabbitmq 0.0
+# HELP postgres_size The database size
+# TYPE postgres_size gauge
+postgres_size{database="opensrp",} 1.2512801439E10
+# HELP health_check_postgres  
+# TYPE health_check_postgres gauge
+health_check_postgres 1.0
+jvm_threads_states_threads{state="blocked",} 0.0
+```
+
+#### Configurations for the Endpoint
+
+| Configuration                               | Description                                    | Type    | Default | 
+|---------------------------------------------|------------------------------------------------|---------|---------|
+| metrics.tags  | Refers to the common tags to be added on all metrics | Map | {}  |
+| metrics.health_check_updater.cron        | Cron schedule for updating health indicator (custom metrics)      | Integer | 1minute  |
+| metrics.additional_ip_allowed       | ip or pattern for access metrics endpoint without authentication e.g  192.168.100.0/8 or 192.168.100.3 (only one ip) | String | ""  |
+| metrics.include       | metrics to be include  | Set (Comma separated string) | "all"  |
+| metrics.exclude       | metrics to be excluded  | Set (Comma separated string) | ""  |
+
+> Available metrics:
+> `all,log4j2,jvm_thread,jvm_thread,jvm_gc,jvm_mem,cpu,uptime,db,disk_space`
+
+> Health indicators [above](#health-endpoint) are added as gauge meters with name in the following pattern; health_check_%s, `%s` is a placeholder for service name e.g health_check_postgres 
+
+The above configs can be updated on `opensrp.properties` file.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ jvm_threads_states_threads{state="blocked",} 0.0
 | metrics.additional_ip_allowed       | ip or pattern for access metrics endpoint without authentication e.g  192.168.100.0/8 or 192.168.100.3 (only one ip) | String | ""  |
 | metrics.include       | metrics to be include  | Set (Comma separated string) | "all"  |
 | metrics.exclude       | metrics to be excluded  | Set (Comma separated string) | ""  |
+| metrics.permitAll       | permits access to metrics endpoint without authentication (Set true if restriction on reverse proxy configs, otherwise whitelist ip if needed) | Boolean | false  |
 
 > Available metrics:
 > `all,log4j2,jvm_thread,jvm_thread,jvm_gc,jvm_mem,cpu,uptime,db,disk_space`

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.32-SNAPSHOT</version>
+    <version>2.8.33-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -107,6 +107,7 @@
             <id>spring plugin repo</id>
             <url>https://repo.spring.io/plugins-release/</url>
         </repository>
+
     </repositories>
 
     <dependencies>
@@ -418,6 +419,11 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
             <version>2.14.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.7.5</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/opensrp/web/Constants.java
+++ b/src/main/java/org/opensrp/web/Constants.java
@@ -79,5 +79,18 @@ public interface Constants {
         String TIME = "serverTime";
         String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
         String VERSION = "buildVersion";
+        String HEALTH_CHECK_PLACEHOLDER = "health_check_%s";
+    }
+
+    interface Metrics {
+        String LOG4J2 = "log4j2";
+        String JVM_THREAD = "jvm_thread";
+        String JVM_GC = "jvm_gc";
+        String JVM_MEMORY = "jvm_mem";
+        String PROCESSOR = "cpu";
+        String UPTIME = "uptime";
+        String DATABASE = "db";
+        String DISK_SPACE = "disk_space";
+        String ALL = "all";
     }
 }

--- a/src/main/java/org/opensrp/web/config/HealthCheckMetricUpdater.java
+++ b/src/main/java/org/opensrp/web/config/HealthCheckMetricUpdater.java
@@ -2,8 +2,6 @@ package org.opensrp.web.config;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensrp.web.Constants;
 import org.opensrp.web.contract.ServiceHealthIndicator;
 import org.opensrp.web.service.HealthService;
@@ -25,8 +23,6 @@ public class HealthCheckMetricUpdater {
 	private HealthService healthService;
 
 	private Map<String, Double> healthCheckIndicatorMap = new HashMap<>();
-
-	private static final Logger logger = LogManager.getLogger(HealthCheckMetricUpdater.class.toString());
 
 	@PostConstruct
 	private void init() {

--- a/src/main/java/org/opensrp/web/config/HealthCheckMetricUpdater.java
+++ b/src/main/java/org/opensrp/web/config/HealthCheckMetricUpdater.java
@@ -1,0 +1,50 @@
+package org.opensrp.web.config;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensrp.web.Constants;
+import org.opensrp.web.contract.ServiceHealthIndicator;
+import org.opensrp.web.service.HealthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.ui.ModelMap;
+
+import javax.annotation.PostConstruct;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class HealthCheckMetricUpdater {
+
+	@Autowired
+	private MeterRegistry registry;
+
+	@Autowired
+	private HealthService healthService;
+
+	private Map<String, Double> healthCheckIndicatorMap = new HashMap<>();
+
+	private static final Logger logger = LogManager.getLogger(HealthCheckMetricUpdater.class.toString());
+
+	@PostConstruct
+	private void init() {
+		for (ServiceHealthIndicator healthIndicator : healthService.getHealthIndicators()) {
+			Gauge.builder(String.format(Constants.HealthIndicator.HEALTH_CHECK_PLACEHOLDER,
+									healthIndicator.getHealthIndicatorKey()),
+							() -> healthCheckIndicatorMap.getOrDefault(healthIndicator.getHealthIndicatorKey(), 0.0))
+					.register(registry);
+		}
+	}
+
+	public void updateHealthStatusMetrics() {
+		ModelMap modelMap = healthService.aggregateHealthCheck();
+		ModelMap serviceMap = (ModelMap) modelMap.get(Constants.HealthIndicator.SERVICES);
+		for (Map.Entry<String, Object> entry : serviceMap.entrySet()) {
+			String indicator = entry.getKey();
+			Boolean status = (Boolean) entry.getValue();
+			healthCheckIndicatorMap.put(indicator, status ? 1.0 : 0.0);
+		}
+	}
+}

--- a/src/main/java/org/opensrp/web/config/MetricsConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/MetricsConfiguration.java
@@ -1,0 +1,170 @@
+package org.opensrp.web.config;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.db.PostgreSQLDatabaseMetrics;
+import io.micrometer.core.instrument.binder.jvm.DiskSpaceMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.logging.Log4j2Metrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensrp.web.Constants;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import javax.sql.DataSource;
+import java.io.File;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Configuration
+public class MetricsConfiguration {
+
+	private static final Logger logger = LogManager.getLogger(MetricsConfiguration.class.toString());
+
+	@Value("#{opensrp['metrics.tags'] ?: {} }")
+	private String metricsTags;
+
+	@Value("#{opensrp['sentry.tags'] ?: {} }")
+	private String sentryTags;
+
+	@Autowired
+	private DataSource dataSource;
+
+	@Value("#{opensrp['metrics.include'] ?: 'all' }")
+	private Set<String> includedMetrics;
+
+	@Value("#{opensrp['metrics.exclude'] ?: '' }")
+	private Set<String> excludedMetrics;
+
+	private final String buildVersion = this.getClass().getPackage().getImplementationVersion();
+
+	@PostConstruct
+	private void init() {
+		MeterRegistry registry = prometheusMeterRegistry();
+		includeLog4j2Metrics(registry);
+		includeThreadMetrics(registry);
+		includeGCMetrics(registry);
+		includeMemoryMetrics(registry);
+		includeDiskSpaceMetrics(registry);
+		includeProcessorMetrics(registry);
+		includeUptimeMetrics(registry);
+		includeDatabaseMetrics(registry);
+	}
+
+	private void includeDatabaseMetrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.DATABASE) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.DATABASE))) {
+			String databaseConnectionUrl;
+			try {
+				databaseConnectionUrl = dataSource.getConnection().getMetaData().getURL();
+				if (StringUtils.isNotBlank(databaseConnectionUrl)) {
+					String databaseName = databaseConnectionUrl.substring(databaseConnectionUrl.lastIndexOf("/") + 1);
+					new PostgreSQLDatabaseMetrics(dataSource, databaseName).bindTo(registry);
+				}
+			}
+			catch (SQLException e) {
+				logger.error(e);
+			}
+		}
+	}
+
+	private void includeUptimeMetrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.UPTIME) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.UPTIME)))
+			new UptimeMetrics().bindTo(registry);
+	}
+
+	private void includeProcessorMetrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.PROCESSOR) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.PROCESSOR)))
+			new ProcessorMetrics().bindTo(registry);
+	}
+
+	private void includeDiskSpaceMetrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.DISK_SPACE) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.DISK_SPACE)))
+			new DiskSpaceMetrics(new File("/")).bindTo(registry);
+	}
+
+	private void includeMemoryMetrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.JVM_MEMORY) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.JVM_MEMORY)))
+			new JvmMemoryMetrics().bindTo(registry);
+	}
+
+	private void includeGCMetrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.JVM_GC) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.JVM_GC)))
+			new JvmGcMetrics().bindTo(registry);
+	}
+
+	private void includeThreadMetrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.JVM_THREAD) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.JVM_THREAD)))
+			new JvmThreadMetrics().bindTo(registry);
+	}
+
+	private void includeLog4j2Metrics(MeterRegistry registry) {
+		if (!excludedMetrics.contains(Constants.Metrics.LOG4J2) && (includedMetrics.contains(Constants.Metrics.ALL)
+				|| includedMetrics.contains(Constants.Metrics.LOG4J2)))
+			new Log4j2Metrics().bindTo(registry);
+	}
+
+	@Bean(name = "prometheusMeterRegistry")
+	public MeterRegistry prometheusMeterRegistry() {
+		MeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+		List<Tag> tagList = Stream.of(buildMetricsTags(metricsTags, ""), buildMetricsTags(sentryTags, "sentry")).flatMap(
+				Collection::stream).collect(
+				Collectors.toList());
+		tagList.add(Tag.of(Constants.HealthIndicator.VERSION, StringUtils.isBlank(buildVersion) ? "" : buildVersion));
+		meterRegistry.config()
+				.commonTags(tagList);
+		return meterRegistry;
+	}
+
+	@VisibleForTesting
+	protected List<Tag> buildMetricsTags(String tags, String prefix) {
+		List<Tag> tagList = new ArrayList<>();
+		if (StringUtils.isNotBlank(tags)) {
+			Map<String, String> map;
+			try {
+				map = new Gson().fromJson(tags, Map.class);
+				for (Map.Entry<String, String> extraTagsEntry : map.entrySet()) {
+					String key = extraTagsEntry.getKey();
+					if (StringUtils.isNotBlank(key)) {
+						String tagKey;
+						if (StringUtils.isNotBlank(prefix))
+							tagKey = String.format("%s_%s", prefix, extraTagsEntry.getKey());
+						else
+							tagKey = extraTagsEntry.getKey();
+						tagList.add(
+								Tag.of(tagKey, extraTagsEntry.getValue()));
+					}
+				}
+			}
+			catch (Exception e) {
+				logger.error(e);
+			}
+		}
+		return tagList;
+	}
+}

--- a/src/main/java/org/opensrp/web/config/SentryConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/SentryConfiguration.java
@@ -26,7 +26,7 @@ public class SentryConfiguration {
 	@Value("#{opensrp['sentry.environment'] ?: ''}")
 	private String environment;
 
-	@Value("#{opensrp['sentry.tags'] ?: '{}'}")
+	@Value("#{opensrp['sentry.tags'] ?: {} }")
 	private String tags;
 
 	@PostConstruct

--- a/src/main/java/org/opensrp/web/config/security/SecurityConfig.java
+++ b/src/main/java/org/opensrp/web/config/security/SecurityConfig.java
@@ -60,6 +60,9 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 	@Value("#{opensrp['metrics.additional_ip_allowed'] ?: '' }")
 	private String metricsAdditionalIpAllowed;
 
+	@Value("#{opensrp['metrics.permitAll'] ?: false }")
+	private boolean metricsPermitAll;
+
 	@Autowired
 	private KeycloakClientRequestFactory keycloakClientRequestFactory;
 	
@@ -97,10 +100,11 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 			.mvcMatchers("/index.html").permitAll()
 			.mvcMatchers("/health").permitAll()
 			.mvcMatchers("/metrics")
-				.access("(isAuthenticated() or hasIpAddress('127.0.0.1') "
+				.access(metricsPermitAll ? "permitAll()" :
+						" ( isAuthenticated()"
+						+ " or hasIpAddress('127.0.0.1') "
 						+ " or hasIpAddress('"+ InetAddress.getLocalHost().getHostAddress() +"') "
-						+ (StringUtils.isBlank(metricsAdditionalIpAllowed) ? "" : String.format(" or hasIpAddress('%s')",
-						metricsAdditionalIpAllowed)) + ")")
+						+ (StringUtils.isBlank(metricsAdditionalIpAllowed) ? "" : String.format(" or hasIpAddress('%s')",metricsAdditionalIpAllowed)) + ")")
 			.mvcMatchers("/").permitAll()
 			.mvcMatchers("/logout.do").permitAll()
 			.mvcMatchers("/rest/viewconfiguration/**").permitAll()

--- a/src/main/java/org/opensrp/web/contract/ServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/contract/ServiceHealthIndicator.java
@@ -6,4 +6,5 @@ import java.util.concurrent.Callable;
 
 public interface ServiceHealthIndicator {
     Callable<ModelMap> doHealthCheck();
+    String getHealthIndicatorKey();
 }

--- a/src/main/java/org/opensrp/web/controller/MetricsController.java
+++ b/src/main/java/org/opensrp/web/controller/MetricsController.java
@@ -1,0 +1,25 @@
+package org.opensrp.web.controller;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.exporter.common.TextFormat;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/metrics")
+public class MetricsController {
+
+	@Autowired
+	private PrometheusMeterRegistry registry;
+
+	@GetMapping
+	public ResponseEntity<String> index() {
+		return ResponseEntity.status(HttpStatus.OK).contentType(MediaType.valueOf(TextFormat.CONTENT_TYPE_004))
+				.body(registry.scrape());
+	}
+}

--- a/src/main/java/org/opensrp/web/health/JdbcServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/health/JdbcServiceHealthIndicator.java
@@ -47,4 +47,9 @@ public class JdbcServiceHealthIndicator implements ServiceHealthIndicator {
 			return modelMap;
 		};
 	}
+
+	@Override
+	public String getHealthIndicatorKey() {
+		return HEALTH_INDICATOR_KEY;
+	}
 }

--- a/src/main/java/org/opensrp/web/health/KeycloakServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/health/KeycloakServiceHealthIndicator.java
@@ -58,4 +58,9 @@ public class KeycloakServiceHealthIndicator implements ServiceHealthIndicator {
 			return modelMap;
 		};
 	}
+
+	@Override
+	public String getHealthIndicatorKey() {
+		return HEALTH_INDICATOR_KEY;
+	}
 }

--- a/src/main/java/org/opensrp/web/health/RabbitmqServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/health/RabbitmqServiceHealthIndicator.java
@@ -45,4 +45,9 @@ public class RabbitmqServiceHealthIndicator implements ServiceHealthIndicator {
 			return modelMap;
 		};
 	}
+
+	@Override
+	public String getHealthIndicatorKey() {
+		return HEALTH_INDICATOR_KEY;
+	}
 }

--- a/src/main/java/org/opensrp/web/health/RedisServiceHealthIndicator.java
+++ b/src/main/java/org/opensrp/web/health/RedisServiceHealthIndicator.java
@@ -42,4 +42,9 @@ public class RedisServiceHealthIndicator implements ServiceHealthIndicator {
 			return modelMap;
 		};
 	}
+
+	@Override
+	public String getHealthIndicatorKey() {
+		return HEALTH_INDICATOR_KEY;
+	}
 }

--- a/src/main/java/org/opensrp/web/service/HealthService.java
+++ b/src/main/java/org/opensrp/web/service/HealthService.java
@@ -1,8 +1,13 @@
 package org.opensrp.web.service;
 
+import org.opensrp.web.contract.ServiceHealthIndicator;
 import org.springframework.ui.ModelMap;
+
+import java.util.List;
 
 public interface HealthService {
 
 	ModelMap aggregateHealthCheck();
+
+	List<ServiceHealthIndicator> getHealthIndicators();
 }

--- a/src/main/java/org/opensrp/web/serviceimpl/HealthServiceImpl.java
+++ b/src/main/java/org/opensrp/web/serviceimpl/HealthServiceImpl.java
@@ -42,14 +42,19 @@ public class HealthServiceImpl implements HealthService {
 
 	private final String buildVersion = this.getClass().getPackage().getImplementationVersion();
 
-	private List<ServiceHealthIndicator> getHealthIndicators() {
-		List<ServiceHealthIndicator> healthIndicators = new ArrayList<>();
-		healthIndicators.add(jdbcServiceHealthIndicator);
-		healthIndicators.add(redisServiceHealthIndicator);
-		if (rabbitmqServiceHealthIndicator != null)
-			healthIndicators.add(rabbitmqServiceHealthIndicator);
-		if (keycloakServiceHealthIndicator != null)
-			healthIndicators.add(keycloakServiceHealthIndicator);
+	private List<ServiceHealthIndicator> healthIndicators;
+
+	@Override
+	public List<ServiceHealthIndicator> getHealthIndicators() {
+		if (healthIndicators == null) {
+			healthIndicators = new ArrayList<>();
+			healthIndicators.add(jdbcServiceHealthIndicator);
+			healthIndicators.add(redisServiceHealthIndicator);
+			if (rabbitmqServiceHealthIndicator != null)
+				healthIndicators.add(rabbitmqServiceHealthIndicator);
+			if (keycloakServiceHealthIndicator != null)
+				healthIndicators.add(keycloakServiceHealthIndicator);
+		}
 		return healthIndicators;
 	}
 

--- a/src/main/webapp/index.html
+++ b/src/main/webapp/index.html
@@ -4,9 +4,6 @@
   Welcome to OpenSRP!
   
   
-  
-  <form >
-  
-  </form>
+
   </body>
 </html>

--- a/src/test/java/org/opensrp/TestDatabaseConfig.java
+++ b/src/test/java/org/opensrp/TestDatabaseConfig.java
@@ -6,6 +6,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 
 import javax.sql.DataSource;
 
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 @Configuration
@@ -13,7 +18,19 @@ public class TestDatabaseConfig {
 
     @Bean
     public DataSource dataSource() {
-        return mock(DataSource.class);
+        String databaseUrl = "jdbc:postgresql://localhost:5432/opensrp";
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        DatabaseMetaData databaseMetaData = mock(DatabaseMetaData.class);
+        try {
+            doReturn(connection).when(dataSource).getConnection();
+            doReturn(databaseMetaData).when(connection).getMetaData();
+            doReturn(databaseUrl).when(databaseMetaData).getURL();
+        }
+        catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return dataSource;
     }
 
     @Bean

--- a/src/test/java/org/opensrp/web/config/HealthCheckMetricUpdaterTest.java
+++ b/src/test/java/org/opensrp/web/config/HealthCheckMetricUpdaterTest.java
@@ -1,0 +1,51 @@
+package org.opensrp.web.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.opensrp.web.Constants;
+import org.opensrp.web.rest.it.TestWebContextLoader;
+import org.opensrp.web.service.HealthService;
+import org.powermock.reflect.internal.WhiteboxImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.ui.ModelMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader = TestWebContextLoader.class, locations = { "classpath:test-webmvc-config.xml", })
+public class HealthCheckMetricUpdaterTest {
+
+	@Autowired
+	private HealthCheckMetricUpdater healthCheckMetricUpdater;
+
+	@Autowired
+	private MeterRegistry meterRegistry;
+
+	@Test
+	public void testInitialization() {
+		assertFalse(meterRegistry.getMeters().isEmpty());
+		assertNotNull(meterRegistry.find("health_check_postgres").gauge());
+		assertNull(meterRegistry.find("health_check_mysql").gauge());
+	}
+
+	@Test
+	public void testUpdateHealthStatusMetrics() {
+		HealthService healthService = mock(HealthService.class);
+		WhiteboxImpl.setInternalState(healthCheckMetricUpdater, "healthService", healthService);
+		ModelMap modelMap = new ModelMap();
+		ModelMap serviceModelMap = new ModelMap();
+		serviceModelMap.put("postgres", true);
+		modelMap.put(Constants.HealthIndicator.SERVICES, serviceModelMap);
+		doReturn(modelMap).when(healthService).aggregateHealthCheck();
+		healthCheckMetricUpdater.updateHealthStatusMetrics();
+		assertEquals(1.0, meterRegistry.find("health_check_postgres").gauge().value(), 0.0);
+	}
+}

--- a/src/test/java/org/opensrp/web/config/MetricsConfigurationTest.java
+++ b/src/test/java/org/opensrp/web/config/MetricsConfigurationTest.java
@@ -1,0 +1,48 @@
+package org.opensrp.web.config;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;
+import org.opensrp.web.rest.it.TestWebContextLoader;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(loader = TestWebContextLoader.class, locations = { "classpath:test-webmvc-config.xml", })
+public class MetricsConfigurationTest {
+
+	@Autowired
+	private MetricsConfiguration metricsConfiguration;
+
+	@Autowired
+	private PrometheusMeterRegistry meterRegistry;
+
+	public void setUp() throws Exception {
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void testInitialization() {
+		assertFalse(meterRegistry.getMeters().isEmpty());
+	}
+
+	@Test
+	public void testBuildMetricsTagsShouldReturnListOfOneTag() {
+		String key = "host";
+		String value = "120.1.2.3";
+		List<Tag> tagList = metricsConfiguration.buildMetricsTags(String.format("{%s: %s}", key, value), "");
+		assertFalse(tagList.isEmpty());
+		assertEquals(1, tagList.size());
+		Tag tag = tagList.get(0);
+		assertEquals(key, tag.getKey());
+		assertEquals(value, tag.getValue());
+	}
+}

--- a/src/test/java/org/opensrp/web/controller/MetricsControllerTest.java
+++ b/src/test/java/org/opensrp/web/controller/MetricsControllerTest.java
@@ -1,0 +1,55 @@
+package org.opensrp.web.controller;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensrp.web.config.security.filter.CrossSiteScriptingPreventionFilter;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MetricsControllerTest {
+
+	@InjectMocks
+	private MetricsController metricsController;
+
+	@Mock
+	private PrometheusMeterRegistry registry;
+
+	private MockMvc mockMvc;
+
+	private final String baseEndpoint = "/metrics";
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.initMocks(this);
+		mockMvc = MockMvcBuilders.standaloneSetup(metricsController)
+				.addFilter(new CrossSiteScriptingPreventionFilter(), "/*").build();
+		ReflectionTestUtils.setField(metricsController, "registry", registry);
+	}
+
+	@Test
+	public void testIndexShouldReturnOk() throws Exception {
+		String sampleOutput= "# HELP health_check_redis  \n"
+				+ "# TYPE health_check_redis gauge\n"
+				+ "health_check_redis 1.0\n"
+				+ "# HELP postgres_connections Number of active connections to the given db\n"
+				+ "# TYPE postgres_connections gauge\n"
+				+ "postgres_connections{database=\"opensrp\",} 4.0\n";
+		doReturn(sampleOutput).when(registry).scrape();
+		MvcResult result = mockMvc.perform(get(baseEndpoint))
+				.andExpect(status().isOk()).andReturn();
+
+		assertEquals(HttpStatus.OK.value(), result.getResponse().getStatus());
+	}
+}

--- a/src/test/resources/test-webmvc-config.xml
+++ b/src/test/resources/test-webmvc-config.xml
@@ -65,6 +65,10 @@
 
 	<bean id="rabbitConnectionFactory" class="org.springframework.amqp.rabbit.connection.CachingConnectionFactory" />
 
+	<bean class="org.opensrp.web.config.MetricsConfiguration" />
+
+	<bean class="org.opensrp.web.config.HealthCheckMetricUpdater" />
+
 	<util:properties id="opensrp"
 		location="classpath:/opensrp.properties" />
 


### PR DESCRIPTION
- Adds opensrp server metrics, i.e jvm_gc,jvm_thread,cpu, diskspace,log4j,jvm_memory
- Adds custom metrics for health check.
- Exposes the `/opensrp/metrics` unauthenticated on local ips i.e (`127.0.0.1` and value of `InetAddress.getLocalHost().getHostAddress()`)   and one additional configurable ip otherwise it will require authentication for the rest.