### PR TITLE
add quotes on map defaults (fixes issue in docker env)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.33-SNAPSHOT</version>
+    <version>2.8.34-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/config/MetricsConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/MetricsConfiguration.java
@@ -40,10 +40,10 @@ public class MetricsConfiguration {
 
 	private static final Logger logger = LogManager.getLogger(MetricsConfiguration.class.toString());
 
-	@Value("#{opensrp['metrics.tags'] ?: {} }")
+	@Value("#{opensrp['metrics.tags'] ?: '{}' }")
 	private String metricsTags;
 
-	@Value("#{opensrp['sentry.tags'] ?: {} }")
+	@Value("#{opensrp['sentry.tags'] ?: '{}' }")
 	private String sentryTags;
 
 	@Autowired
@@ -144,7 +144,7 @@ public class MetricsConfiguration {
 	@VisibleForTesting
 	protected List<Tag> buildMetricsTags(String tags, String prefix) {
 		List<Tag> tagList = new ArrayList<>();
-		if (StringUtils.isNotBlank(tags)) {
+		if (StringUtils.isNotBlank(tags) && tags.length() > 2) {
 			Map<String, String> map;
 			try {
 				map = new Gson().fromJson(tags, Map.class);

--- a/src/main/java/org/opensrp/web/config/SentryConfiguration.java
+++ b/src/main/java/org/opensrp/web/config/SentryConfiguration.java
@@ -26,7 +26,7 @@ public class SentryConfiguration {
 	@Value("#{opensrp['sentry.environment'] ?: ''}")
 	private String environment;
 
-	@Value("#{opensrp['sentry.tags'] ?: {} }")
+	@Value("#{opensrp['sentry.tags'] ?: '{}' }")
 	private String tags;
 
 	@PostConstruct
@@ -47,7 +47,7 @@ public class SentryConfiguration {
 	}
 	@VisibleForTesting
 	protected void populateTags(SentryOptions sentryOptions) {
-		if(StringUtils.isNotBlank(tags)) {
+		if(StringUtils.isNotBlank(tags) && tags.length() > 2) {
 			Map<String, String> map;
 			try {
 				map = new Gson().fromJson(tags, Map.class);

--- a/src/test/java/org/opensrp/web/config/SentryConfigurationTest.java
+++ b/src/test/java/org/opensrp/web/config/SentryConfigurationTest.java
@@ -48,7 +48,7 @@ public class SentryConfigurationTest {
 
 	@Test(expected = IllegalAccessError.class)
 	public void testPopulateTagsShouldThrowExceptionIfTagsInvalid() {
-		WhiteboxImpl.setInternalState(sentryConfiguration, "tags", "}");
+		WhiteboxImpl.setInternalState(sentryConfiguration, "tags", "{sample");
 		SentryOptions sentryOptions = mock(SentryOptions.class);
 		sentryConfiguration.populateTags(sentryOptions);
 		verify(sentryOptions, never()).setTag(anyString(), anyString());


### PR DESCRIPTION
Fixes issue with string conversion on docker container.