### PR TITLE
replace executorservice with taskexecutor bean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.34-SNAPSHOT</version>
+    <version>2.8.35-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -25,7 +25,7 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.12.13-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.12.14-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.3.0-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>

--- a/src/main/java/org/opensrp/web/serviceimpl/HealthServiceImpl.java
+++ b/src/main/java/org/opensrp/web/serviceimpl/HealthServiceImpl.java
@@ -11,6 +11,7 @@ import org.opensrp.web.health.RabbitmqServiceHealthIndicator;
 import org.opensrp.web.health.RedisServiceHealthIndicator;
 import org.opensrp.web.service.HealthService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.ModelMap;
 
@@ -20,7 +21,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 @Service("HealthServiceImpl")
@@ -43,6 +43,9 @@ public class HealthServiceImpl implements HealthService {
 	private final String buildVersion = this.getClass().getPackage().getImplementationVersion();
 
 	private List<ServiceHealthIndicator> healthIndicators;
+
+	@Autowired
+	private ThreadPoolTaskExecutor taskExecutor;
 
 	@Override
 	public List<ServiceHealthIndicator> getHealthIndicators() {
@@ -69,7 +72,7 @@ public class HealthServiceImpl implements HealthService {
 		}
 
 		try {
-			List<Future<ModelMap>> futureList = Executors.newFixedThreadPool(callableList.size()).invokeAll(callableList);
+			List<Future<ModelMap>> futureList = taskExecutor.getThreadPoolExecutor().invokeAll(callableList);
 			for (Future<ModelMap> resultFuture : futureList) {
 				ModelMap modelMap = resultFuture.get();
 				Boolean status = (Boolean) modelMap.get(Constants.HealthIndicator.STATUS);

--- a/src/test/resources/test-webmvc-config.xml
+++ b/src/test/resources/test-webmvc-config.xml
@@ -69,6 +69,12 @@
 
 	<bean class="org.opensrp.web.config.HealthCheckMetricUpdater" />
 
+	<bean id="taskExecutor" class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor">
+		<property name="corePoolSize" value="5" />
+		<property name="maxPoolSize" value="10" />
+		<property name="queueCapacity" value="25" />
+	</bean>
+
 	<util:properties id="opensrp"
 		location="classpath:/opensrp.properties" />
 


### PR DESCRIPTION

This change provides a threadpooltaskexecutor bean that can be used as singleton instead of initializing Executor service when needed. This will prevent multiple executor service from being created.