### PR TITLE
Security patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # opensrp-server-web
 
-[![Build Status](https://travis-ci.org/OpenSRP/opensrp-server-web.svg?branch=master)](https://travis-ci.org/OpenSRP/opensrp-server-web) [![Coverage Status](https://coveralls.io/repos/github/OpenSRP/opensrp-server-web/badge.svg?branch=master)](https://coveralls.io/github/OpenSRP/opensrp-server-web?branch=master) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/5544ce1a89924b919197c902819c83eb)](https://www.codacy.com/app/OpenSRP/opensrp-server-web?utm\_source=github.com\&utm\_medium=referral\&utm\_content=OpenSRP/opensrp-server-web\&utm\_campaign=Badge\_Grade)
+[![Build Status](https://travis-ci.org/OpenSRP/opensrp-server-web.svg?branch=master)](https://travis-ci.org/OpenSRP/opensrp-server-web) [![Coverage Status](https://coveralls.io/repos/github/OpenSRP/opensrp-server-web/badge.svg?branch=master)](https://coveralls.io/github/OpenSRP/opensrp-server-web?branch=master) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/c2739ddb2c6640fe8a926eface8b5846)](https://www.codacy.com/gh/opensrp/opensrp-server-web/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=opensrp/opensrp-server-web&amp;utm_campaign=Badge_Grade)
 
 ## Overview
 

--- a/pom.xml
+++ b/pom.xml
@@ -380,7 +380,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.20.Final</version>
+            <version>6.0.22.Final</version>
         </dependency>
         <dependency>
             <groupId>io.sentry</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -412,12 +412,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>3.0.11-SNAPSHOT</version>
+    <version>3.0.12-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -17,7 +17,7 @@
         <hibernate-entitymanager.version>5.4.12.Final</hibernate-entitymanager.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.2.4.RELEASE</spring.version> 
-        <spring.security.version>5.3.10.RELEASE</spring.security.version> 
+        <spring.security.version>5.3.12.RELEASE</spring.security.version>
         <spring.security.oauth.version>2.5.0.RELEASE</spring.security.oauth.version>
         <spring.fox.swagger.version>2.9.2</spring.fox.swagger.version>
         <spring.data.redis>2.2.4.RELEASE</spring.data.redis>
@@ -25,8 +25,8 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>3.0.7-SNAPSHOT</opensrp.core.version>
-        <opensrp.connector.version>2.3.0-SNAPSHOT</opensrp.connector.version>
+        <opensrp.core.version>3.0.8-SNAPSHOT</opensrp.core.version>
+        <opensrp.connector.version>2.3.2-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
         <powermock.version>2.0.5</powermock.version>


### PR DESCRIPTION
**Migrate dependencies**
- Server core to 3.0.8
- Server connector to 2.3.2-SNAPSHOT
- Spring security to 5.3.12.RELEASE