### PR TITLE
Security updates: Migrate dependencies v2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.37-SNAPSHOT</version>
+    <version>2.8.38-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -17,7 +17,7 @@
         <hibernate-entitymanager.version>5.4.12.Final</hibernate-entitymanager.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>5.2.4.RELEASE</spring.version>
-        <spring.security.version>5.3.3.RELEASE</spring.security.version>
+        <spring.security.version>5.3.12.RELEASE</spring.security.version>
         <spring.security.oauth.version>2.4.0.RELEASE</spring.security.oauth.version>
         <spring.fox.swagger.version>2.9.2</spring.fox.swagger.version>
         <spring.data.redis>2.2.4.RELEASE</spring.data.redis>
@@ -25,8 +25,8 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.12.16-SNAPSHOT</opensrp.core.version>
-        <opensrp.connector.version>2.3.0-SNAPSHOT</opensrp.connector.version>
+        <opensrp.core.version>2.12.17-SNAPSHOT</opensrp.core.version>
+        <opensrp.connector.version>2.3.2-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
         <powermock.version>2.0.5</powermock.version>
@@ -168,7 +168,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -381,7 +381,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.18.Final</version>
+            <version>6.0.22.Final</version>
         </dependency>
         <dependency>
             <groupId>io.sentry</groupId>
@@ -413,12 +413,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/src/main/java/org/opensrp/web/rest/PlanResource.java
+++ b/src/main/java/org/opensrp/web/rest/PlanResource.java
@@ -580,6 +580,10 @@ public class PlanResource {
 		}
 	}
 
+	public Date getCurrentDate(){
+		return new Date();
+	}
+
 	public PlanDefinition createPlanFromTemplate(String templateString, Event caseDetailsEvent) {
 		// Build map
 		Map<String, String> valuesMap = new HashMap<>();
@@ -588,7 +592,7 @@ public class PlanResource {
 				caseDetailsEvent.getDetails().get(Constants.Plan.PLAN_IDENTIFIER) : UUID.randomUUID().toString();
 		valuesMap.put(Constants.Plan.PLAN_IDENTIFIER, planIdentifier);
 		SimpleDateFormat sdf = new SimpleDateFormat(Constants.Plan.DATE_FORMAT);
-		Date currentDate = new Date();
+		Date currentDate = getCurrentDate();
 		Date endDate;
 		Calendar c = Calendar.getInstance();
 		c.setTime(currentDate);

--- a/src/test/java/org/opensrp/web/rest/PlanResourceTest.java
+++ b/src/test/java/org/opensrp/web/rest/PlanResourceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -32,8 +33,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Date;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.joda.time.DateTime;
 import org.json.JSONObject;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1736,7 +1739,11 @@ public class PlanResourceTest extends BaseSecureResourceTest<PlanDefinition> {
 		Template template = gson.fromJson(templateString, Template.class);
 		when(templateService.getTemplateByTemplateId(1)).thenReturn(template);
 
-		planResource.generateCaseTriggeredPlans();
+	    PlanResource planResourceSpy = spy(planResource);
+		Date todayDate = new DateTime(2021, 12, 10, 0, 0, 0, 0).toDate();
+		when(planResourceSpy.getCurrentDate()).thenReturn(todayDate);
+
+		planResourceSpy.generateCaseTriggeredPlans();
 
 		verify(planService).addPlan(argumentCaptor.capture(), stringArgumentCaptor.capture());
 		assertEquals(Constants.Plan.PLAN_USER, stringArgumentCaptor.getValue());


### PR DESCRIPTION
**Security updates: Migrate dependencies**

- Server core to 2.12.17
- Server connector to 2.3.2-SNAPSHOT
- Spring security to 5.3.12.RELEASE
- log4j-slf4j-impl to 2.15.0
- log4j-jcl to 2.15.0

Bump up artifact version to 2.3.8