### PR TITLE
Security updates: Migrate dependencies v2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.smartregister</groupId>
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.1.54.1-SNAPSHOT</version>
+	<version>2.1.54.2-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -16,7 +16,7 @@
 		<hibernate-entitymanager.version>5.4.12.Final</hibernate-entitymanager.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.version>5.2.4.RELEASE</spring.version>
-		<spring.security.version>5.2.2.RELEASE</spring.security.version>
+		<spring.security.version>5.2.12.RELEASE</spring.security.version>
 		<spring.security.oauth.version>2.4.0.RELEASE</spring.security.oauth.version>
 		<spring.fox.swagger.version>2.9.2</spring.fox.swagger.version>
 		<spring.data.redis>2.2.4.RELEASE</spring.data.redis>
@@ -24,8 +24,8 @@
 		<redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
 		<opensrp.updatePolicy>always</opensrp.updatePolicy>
 		<nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-		<opensrp.core.version>2.12.14-SNAPSHOT</opensrp.core.version>
-		<opensrp.connector.version>2.3.0-SNAPSHOT</opensrp.connector.version>
+		<opensrp.core.version>2.12.17-SNAPSHOT</opensrp.core.version>
+		<opensrp.connector.version>2.3.2-SNAPSHOT</opensrp.connector.version>
 
 		<opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.6.0</version>
+            <version>1.6.6</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -386,12 +386,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
          <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
-            <version>2.14.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>


### PR DESCRIPTION
- Server core to 2.12.17
- Server connector to 2.3.2-SNAPSHOT
- Spring security to 5.3.12.RELEASE
- Log4j-slf4j-impl to 2.15.0
- Log4j-jcl to 2.15.0

Bump up artifact version to 2.1.54.2