### PR TITLE
Add plan generation error logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.12.17-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.12.18-ALPHA1-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.3.2-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.12.18-ALPHA1-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.12.18-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.3.2-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.38-SNAPSHOT</version>
+    <version>2.8.39-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/Constants.java
+++ b/src/main/java/org/opensrp/web/Constants.java
@@ -106,6 +106,11 @@ public interface Constants {
         String LARVAL_DIPPING_ACTION_ID = "larvalDippingActionId";
         String MOSQUITO_COLLECTION_ID = "mosquitoCollectionActionId";
         String OPENSRP_CASE_CLASSIFICATION_EVENT_ID = "opensrpCaseClassificationEventId";
+        String TEMPLATE_NOT_FOUND = "Plan template not found";
+        String JURISDICTION_NOT_FOUND = "Jurisdiction not found";
+        String BIOPHICS_ID_MISSING = "Biophics id missing from case details event";
+        String INVALID_CASE_DETAILS_EVENT = "Case details event is invalid";
+        String MISSING_CASE_DETAILS_EVENT = "Case details event does not exist";
         String EXTERNAL_ID = "externalId";
         String PLAN_USER = "opensrp";
         String BFID = "bfid";

--- a/src/test/java/org/opensrp/web/rest/PlanResourceTest.java
+++ b/src/test/java/org/opensrp/web/rest/PlanResourceTest.java
@@ -1860,7 +1860,6 @@ public class PlanResourceTest extends BaseSecureResourceTest<PlanDefinition> {
 
 	@Test
 	public void testGenerateCaseTriggeredPlansLogsErrorWhenTemplateIsMissing() {
-		PlanDefinition expectedPlan = gson.fromJson(caseTriggeredPlanJson, PlanDefinition.class);
 		PlanProcessingStatus status = new PlanProcessingStatus();
 		status.setStatus(0);
 		status.setTemplateId(1l);


### PR DESCRIPTION
There is a need to add logging of errors in the plan generation process. These will be logged in the `error_log` field in the plan_processing_status table