### PR TITLE
Update the connector version to get the dhis2 push using opensrp saved locations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>3.0.10-SNAPSHOT</version>
+    <version>3.0.11-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -26,7 +26,7 @@
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
         <opensrp.core.version>3.0.6-SNAPSHOT</opensrp.core.version>
-        <opensrp.connector.version>2.3.0-SNAPSHOT</opensrp.connector.version>
+        <opensrp.connector.version>2.3.3-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
         <powermock.version>2.0.5</powermock.version>


### PR DESCRIPTION
:arrow_up: Update the connector version to get the dhis2 push using opensrp saved locations

Depends on https://github.com/opensrp/opensrp-server-connector/pull/68