### PR TITLE
Log4j security patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ The metrics endpoint of the opensrp server is `/opensrp/metrics`. It returns inf
 The endpoint is only accessible through the following ips when unauthenticated but requires authentication for the any other ips:
 
 *   `127.0.0.1`,
-*   `InetAddress.getLocalHost().getHostAddress()`,
 *   One additional configurable ip, kindly check below `metrics.additional_ip_allowed`
 
 Sample responses from the metrics endpoint are as follows:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>3.0.13-SNAPSHOT</version>
+    <version>3.0.14-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -25,8 +25,8 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>3.0.9-SNAPSHOT</opensrp.core.version>
-        <opensrp.connector.version>2.3.2-SNAPSHOT</opensrp.connector.version>
+        <opensrp.core.version>3.0.10-SNAPSHOT</opensrp.core.version>
+        <opensrp.connector.version>2.3.3-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
         <powermock.version>2.0.5</powermock.version>
@@ -385,7 +385,7 @@
         <dependency>
             <groupId>io.sentry</groupId>
             <artifactId>sentry-log4j2</artifactId>
-            <version>4.3.0</version>
+            <version>5.5.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.lettuce/lettuce-core -->
@@ -412,17 +412,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-jcl</artifactId>
-            <version>2.15.0</version>
+            <version>2.16.0</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-registry-prometheus</artifactId>
-            <version>1.7.5</version>
+            <version>1.8.1</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/opensrp/web/config/security/SecurityConfig.java
+++ b/src/main/java/org/opensrp/web/config/security/SecurityConfig.java
@@ -103,7 +103,6 @@ public class SecurityConfig extends KeycloakWebSecurityConfigurerAdapter {
 				.access(metricsPermitAll ? "permitAll()" :
 						" ( isAuthenticated()"
 						+ " or hasIpAddress('127.0.0.1') "
-						+ " or hasIpAddress('"+ InetAddress.getLocalHost().getHostAddress() +"') "
 						+ (StringUtils.isBlank(metricsAdditionalIpAllowed) ? "" : String.format(" or hasIpAddress('%s')",metricsAdditionalIpAllowed)) + ")")
 			.mvcMatchers("/").permitAll()
 			.mvcMatchers("/logout.do").permitAll()


### PR DESCRIPTION
- Update sentry log4j to 5.5.0
- Update log4j to v2.16.0
- Remove whitelisting of the value of InetAddress.getLocalHost().getHostAddress() since in some servers it returns public ip.
- Update readme to reflect the above change.