### PR TITLE
Fix plan template action deserialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.8.40-SNAPSHOT</version>
+    <version>2.8.41-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <redis.lettuce.version>5.2.2.RELEASE</redis.lettuce.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.12.19-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.12.20-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.3.3-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>


### PR DESCRIPTION
Posting templates via the `rest/templates` API is failing due to an error during de-serialization of the template