### PR TITLE
Log More Details for Clients/Events That Fail to Sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>3.2.5-SNAPSHOT</version>
+    <version>3.2.6-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>

--- a/src/main/java/org/opensrp/web/rest/EventResource.java
+++ b/src/main/java/org/opensrp/web/rest/EventResource.java
@@ -509,7 +509,7 @@ public class EventResource extends RestResource<Event> {
 						clientService.addorUpdate(client);
 					}
 					catch (Exception e) {
-						logger.error("[SYNC_INFO] Sync failed for client {} - {}", client.getBaseEntityId(), gson.toJson(client), e);
+						logger.error("[SYNC_INFO] Sync failed for client {}; identifiers: {}", client.getBaseEntityId(), gson.toJson(client.getIdentifiers()), e);
 						failedClientsIds.add(client.getBaseEntityId());
 					}
 				}
@@ -532,11 +532,10 @@ public class EventResource extends RestResource<Event> {
 					}
 					catch (Exception e) {
 						logger.error(
-								"[SYNC_INFO] Sync failed for event {}; type: {} for client {} - {}",
+								"[SYNC_INFO] Sync failed for event {}; type: {} for client {}",
 								event.getFormSubmissionId(),
 								event.getEventType(),
 								event.getBaseEntityId(),
-								gson.toJson(event),
 								e
 						);
 						failedEventIds.add(event.getFormSubmissionId());

--- a/src/main/java/org/opensrp/web/rest/EventResource.java
+++ b/src/main/java/org/opensrp/web/rest/EventResource.java
@@ -509,7 +509,7 @@ public class EventResource extends RestResource<Event> {
 						clientService.addorUpdate(client);
 					}
 					catch (Exception e) {
-						logger.error("Client {} failed to sync", client.getBaseEntityId(), e);
+						logger.error("[SYNC_INFO] Sync failed for client {} - {}", client.getBaseEntityId(), gson.toJson(client), e);
 						failedClientsIds.add(client.getBaseEntityId());
 					}
 				}
@@ -531,14 +531,21 @@ public class EventResource extends RestResource<Event> {
 						logger.info("[SYNC_INFO] Event {} of type {} saved", event.getFormSubmissionId(), event.getEventType());
 					}
 					catch (Exception e) {
-						logger.error("Event {} of type {} for client {} failed to sync", event.getFormSubmissionId(), event.getEventType(), event.getBaseEntityId(), e);
+						logger.error(
+								"[SYNC_INFO] Sync failed for event {}; type: {} for client {} - {}",
+								event.getFormSubmissionId(),
+								event.getEventType(),
+								event.getBaseEntityId(),
+								gson.toJson(event),
+								e
+						);
 						failedEventIds.add(event.getFormSubmissionId());
 					}
 				}
 			}
 		}
 		catch (Exception e) {
-			logger.error("Sync data processing failed with exception: ", e);
+			logger.error("[SYNC_INFO] Sync data processing failed with exception: ", e);
 			return new ResponseEntity<>(INTERNAL_SERVER_ERROR);
 		}
 


### PR DESCRIPTION
Include request JSON for each failed clients and events in the log entry for troubleshooting