### PR TITLE
allow migrations to continue after getting warning msgs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.10.5-SNAPSHOT</version>
+    <version>2.10.6-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>


### PR DESCRIPTION
- Made `throw_warning` false to prevent warning msgs from halting the migration process.