### PR TITLE
Allow migration continue after warning msgs v2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.smartregister</groupId>
 	<artifactId>opensrp-server-web</artifactId>
 	<packaging>war</packaging>
-	<version>2.1.70.3-SNAPSHOT</version>
+	<version>2.1.70.4-SNAPSHOT</version>
 	<name>opensrp-server-web</name>
 	<description>OpenSRP Server Web Application</description>
 	<url>https://github.com/OpenSRP/opensrp-server-web</url>


### PR DESCRIPTION
- Made `throw_warning` false to prevent warning msgs from halting the migration process.