### PR TITLE
update plans after stock and structure mutation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.10.12-ALPHA1-SNAPSHOT</version>
+    <version>2.10.12-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -24,7 +24,7 @@
         <redis.jedis.version>3.8.0</redis.jedis.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.14.9-ALPHA-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.14.9-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.4.1-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <powermock.version>2.0.5</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.10.10-SNAPSHOT</version>
+    <version>2.10.12-ALPHA-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -24,7 +24,7 @@
         <redis.jedis.version>3.8.0</redis.jedis.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.14.5-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.14.9-DEV3-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.4.1-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <powermock.version>2.0.5</powermock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>opensrp-server-web</artifactId>
     <packaging>war</packaging>
-    <version>2.10.12-ALPHA-SNAPSHOT</version>
+    <version>2.10.12-ALPHA1-SNAPSHOT</version>
     <name>opensrp-server-web</name>
     <description>OpenSRP Server Web Application</description>
     <url>https://github.com/OpenSRP/opensrp-server-web</url>
@@ -24,7 +24,7 @@
         <redis.jedis.version>3.8.0</redis.jedis.version>
         <opensrp.updatePolicy>always</opensrp.updatePolicy>
         <nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
-        <opensrp.core.version>2.14.9-DEV3-SNAPSHOT</opensrp.core.version>
+        <opensrp.core.version>2.14.9-ALPHA-SNAPSHOT</opensrp.core.version>
         <opensrp.connector.version>2.4.1-SNAPSHOT</opensrp.connector.version>
         <opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
         <powermock.version>2.0.5</powermock.version>

--- a/src/main/java/org/opensrp/web/listener/StructureRepositoryEventListener.java
+++ b/src/main/java/org/opensrp/web/listener/StructureRepositoryEventListener.java
@@ -1,0 +1,23 @@
+package org.opensrp.web.listener;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensrp.domain.postgres.Structure;
+import org.opensrp.repository.StructureCreateOrUpdateEvent;
+import org.opensrp.service.PhysicalLocationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StructureRepositoryEventListener  implements ApplicationListener<StructureCreateOrUpdateEvent> {
+	private static final Logger logger = LogManager.getLogger(StructureRepositoryEventListener.class.toString());
+	@Autowired
+	private PhysicalLocationService physicalLocationService;
+	@Override
+	public void onApplicationEvent(StructureCreateOrUpdateEvent structureCreateOrUpdateEvent) {
+		Structure structure = (Structure) structureCreateOrUpdateEvent.getSource();
+		logger.info("updating structure qw "+structure.getJson());
+		physicalLocationService.regenerateTasksForOperationalArea(structure);
+	}
+}

--- a/src/main/java/org/opensrp/web/listener/StructureRepositoryEventListener.java
+++ b/src/main/java/org/opensrp/web/listener/StructureRepositoryEventListener.java
@@ -17,7 +17,7 @@ public class StructureRepositoryEventListener  implements ApplicationListener<St
 	@Override
 	public void onApplicationEvent(StructureCreateOrUpdateEvent structureCreateOrUpdateEvent) {
 		Structure structure = (Structure) structureCreateOrUpdateEvent.getSource();
-		logger.info("Receiving Strucute Event");
+		logger.info("Receiving Structure Event");
 		physicalLocationService.regenerateTasksForOperationalArea(structure);
 	}
 }

--- a/src/main/java/org/opensrp/web/listener/StructureRepositoryEventListener.java
+++ b/src/main/java/org/opensrp/web/listener/StructureRepositoryEventListener.java
@@ -17,7 +17,7 @@ public class StructureRepositoryEventListener  implements ApplicationListener<St
 	@Override
 	public void onApplicationEvent(StructureCreateOrUpdateEvent structureCreateOrUpdateEvent) {
 		Structure structure = (Structure) structureCreateOrUpdateEvent.getSource();
-		logger.info("updating structure qw "+structure.getJson());
+		logger.info("Receiving Strucute Event");
 		physicalLocationService.regenerateTasksForOperationalArea(structure);
 	}
 }

--- a/src/main/resources/spring/listener-context.xml
+++ b/src/main/resources/spring/listener-context.xml
@@ -16,6 +16,9 @@
 	<task:scheduler pool-size="1" id="dhis2Scheduler"/>
     <task:scheduler pool-size="1" id="messageScheduler"/>
 
+	<bean id="structureRepositoryEventListener"
+		  class="org.opensrp.web.listener.StructureRepositoryEventListener"/>
+
 	<beans profile="rapidpro">
 		<bean id="dhis2" class="org.opensrp.web.listener.DHIS2ConnectorListener"></bean>
 		<task:scheduled-tasks scheduler="dhis2Scheduler">


### PR DESCRIPTION
Whenever you create a product, you will need to update the plans so that it triggers task regeneration. This ensures that this happens automatically and the latest service points and products show up in the android application after the next sync